### PR TITLE
Release main/Smdn.Devices.MCP2221-0.9.3

### DIFF
--- a/doc/api-list/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221-net5.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221-net5.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Devices.MCP2221.dll (Smdn.Devices.MCP2221-0.9.2 (net5.0))
+// Smdn.Devices.MCP2221.dll (Smdn.Devices.MCP2221-0.9.3)
 //   Name: Smdn.Devices.MCP2221
-//   AssemblyVersion: 0.9.2.0
-//   InformationalVersion: 0.9.2 (net5.0)
+//   AssemblyVersion: 0.9.3.0
+//   InformationalVersion: 0.9.3+3968a13d13f49f54dd615bc0a80ddf4bd9d3ef84
 //   TargetFramework: .NETCoreApp,Version=v5.0
 //   Configuration: Release
 

--- a/doc/api-list/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Devices.MCP2221.dll (Smdn.Devices.MCP2221-0.9.2 (netstandard2.1))
+// Smdn.Devices.MCP2221.dll (Smdn.Devices.MCP2221-0.9.3)
 //   Name: Smdn.Devices.MCP2221
-//   AssemblyVersion: 0.9.2.0
-//   InformationalVersion: 0.9.2 (netstandard2.1)
+//   AssemblyVersion: 0.9.3.0
+//   InformationalVersion: 0.9.3+3968a13d13f49f54dd615bc0a80ddf4bd9d3ef84
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #1](https://github.com/smdn/Smdn.Devices.MCP2221/actions/runs/1987278022).

# Release target
- package_target_tag: `new-release/main/Smdn.Devices.MCP2221-0.9.3`
- package_id: `Smdn.Devices.MCP2221`
- package_id_with_version: `Smdn.Devices.MCP2221-0.9.3`
- package_version: `0.9.3`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Devices.MCP2221-0.9.3-1647354560`
- release_tag: `releases/Smdn.Devices.MCP2221-0.9.3`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/b7b77b69d440e8de4e92df6f471915b3`](https://gist.github.com/b7b77b69d440e8de4e92df6f471915b3)
- artifact_name_nupkg: `Smdn.Devices.MCP2221.0.9.3.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Devices.MCP2221</id>
    <version>0.9.3</version>
    <title>Smdn.Devices.MCP2221</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Devices.MCP2221.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/electronics/libs/Smdn.Devices.MCP2221/</projectUrl>
    <description>Smdn.Devices.MCP2221 is a .NET library for controlling MCP2221/MCP2221A USB2.0 to I2C/UART Protocol Converter with GPIO.
This library enables you to control MCP2221/MCP2221A's GPIO, I2C interface, and other functionalities via USB-HID interface.</description>
    <copyright>Copyright ©  smdn</copyright>
    <tags>smdn.jp USB,USB-HID,MCP2221,MCP2221A,I2C,GPIO</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Devices.MCP2221" branch="main" commit="3968a13d13f49f54dd615bc0a80ddf4bd9d3ef84" />
    <dependencies>
      <group targetFramework="net5.0">
        <dependency id="HidSharp" version="2.1.0" exclude="Build,Analyzers" />
        <dependency id="Microsoft.Extensions.DependencyInjection" version="5.0.1" exclude="Build,Analyzers" />
        <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
        <dependency id="System.Device.Gpio" version="[1.4.0, 2.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="HidSharp" version="2.1.0" exclude="Build,Analyzers" />
        <dependency id="Microsoft.Extensions.DependencyInjection" version="5.0.1" exclude="Build,Analyzers" />
        <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
        <dependency id="System.Device.Gpio" version="[1.4.0, 2.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/src/Smdn.Devices.MCP2221/bin/Release/net5.0/Smdn.Devices.MCP2221.dll" target="lib/net5.0/Smdn.Devices.MCP2221.dll" />
    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/src/Smdn.Devices.MCP2221/bin/Release/netstandard2.1/Smdn.Devices.MCP2221.dll" target="lib/netstandard2.1/Smdn.Devices.MCP2221.dll" />
    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/.nuget/packages/smdn.msbuild.projectassets.common/1.1.0/project/images/package-icon.png" target="Smdn.Devices.MCP2221.png" />
    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/src/Smdn.Devices.MCP2221/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

