### PR TITLE
Release main/Smdn.Devices.MCP2221-0.9.4

### DIFF
--- a/doc/api-list/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221-net10.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221-net10.0.apilist.cs
@@ -1,14 +1,28 @@
-// Smdn.Devices.MCP2221.dll (Smdn.Devices.MCP2221-0.9.3)
+// Smdn.Devices.MCP2221.dll (Smdn.Devices.MCP2221-0.9.4)
 //   Name: Smdn.Devices.MCP2221
-//   AssemblyVersion: 0.9.3.0
-//   InformationalVersion: 0.9.3+3968a13d13f49f54dd615bc0a80ddf4bd9d3ef84
-//   TargetFramework: .NETCoreApp,Version=v5.0
+//   AssemblyVersion: 0.9.4.0
+//   InformationalVersion: 0.9.4+bcf0f60c80f47181419bd376632a2c0be172ac98
+//   TargetFramework: .NETCoreApp,Version=v10.0
 //   Configuration: Release
+//   Metadata: IsTrimmable=True
+//   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.MCP2221
+//   Metadata: RepositoryBranch=main
+//   Metadata: RepositoryCommit=bcf0f60c80f47181419bd376632a2c0be172ac98
+//   Referenced assemblies:
+//     HidSharp, Version=2.1.0.0, Culture=neutral
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     System.Collections, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.ComponentModel, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Device.Gpio, Version=1.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
+//     System.Linq, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Memory, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Threading.Thread, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 
 using System;
 using System.Collections.Generic;
 using System.Device.Gpio;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -59,13 +73,10 @@ namespace Smdn.Devices.MCP2221 {
     public I2CReadException(string message, Exception innerException) {}
   }
 
-  [Nullable(byte.MinValue)]
-  [NullableContext(1)]
   public class MCP2221 :
     IAsyncDisposable,
     IDisposable
   {
-    [NullableContext(byte.MinValue)]
     public sealed class GP0Functionality : GPFunctionality {
       public void ConfigureAsLEDURX(CancellationToken cancellationToken = default) {}
       public ValueTask ConfigureAsLEDURXAsync(CancellationToken cancellationToken = default) {}
@@ -73,7 +84,6 @@ namespace Smdn.Devices.MCP2221 {
       public ValueTask ConfigureAsSSPNDAsync(CancellationToken cancellationToken = default) {}
     }
 
-    [NullableContext(byte.MinValue)]
     public sealed class GP1Functionality : GPFunctionality {
       public void ConfigureAsADC(CancellationToken cancellationToken = default) {}
       public ValueTask ConfigureAsADCAsync(CancellationToken cancellationToken = default) {}
@@ -85,7 +95,6 @@ namespace Smdn.Devices.MCP2221 {
       public ValueTask ConfigureAsLEDUTXAsync(CancellationToken cancellationToken = default) {}
     }
 
-    [NullableContext(byte.MinValue)]
     public sealed class GP2Functionality : GPFunctionality {
       public void ConfigureAsADC(CancellationToken cancellationToken = default) {}
       public ValueTask ConfigureAsADCAsync(CancellationToken cancellationToken = default) {}
@@ -95,7 +104,6 @@ namespace Smdn.Devices.MCP2221 {
       public ValueTask ConfigureAsUSBCFGAsync(CancellationToken cancellationToken = default) {}
     }
 
-    [NullableContext(byte.MinValue)]
     public sealed class GP3Functionality : GPFunctionality {
       public void ConfigureAsADC(CancellationToken cancellationToken = default) {}
       public ValueTask ConfigureAsADCAsync(CancellationToken cancellationToken = default) {}
@@ -105,7 +113,6 @@ namespace Smdn.Devices.MCP2221 {
       public ValueTask ConfigureAsLEDI2CAsync(CancellationToken cancellationToken = default) {}
     }
 
-    [NullableContext(byte.MinValue)]
     public abstract class GPFunctionality {
       public string PinDesignation { get; }
       public string PinName { get; }
@@ -122,7 +129,6 @@ namespace Smdn.Devices.MCP2221 {
       public ValueTask SetValueAsync(PinValue newValue, CancellationToken cancellationToken = default) {}
     }
 
-    [NullableContext(byte.MinValue)]
     public sealed class I2CFunctionality {
       public const int MaxBlockLength = 65535;
 
@@ -130,23 +136,18 @@ namespace Smdn.Devices.MCP2221 {
 
       public int Read(I2CAddress address, Span<byte> buffer, CancellationToken cancellationToken = default) {}
       public int Read(I2CAddress address, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-      [AsyncStateMachine]
-      public ValueTask<int> ReadAsync(I2CAddress address, Memory<byte> buffer, CancellationToken cancellationToken = default) {}
       public ValueTask<int> ReadAsync(I2CAddress address, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public async ValueTask<int> ReadAsync(I2CAddress address, Memory<byte> buffer, CancellationToken cancellationToken = default) {}
       public int ReadByte(I2CAddress address, CancellationToken cancellationToken = default) {}
-      [AsyncStateMachine]
-      public ValueTask<int> ReadByteAsync(I2CAddress address, CancellationToken cancellationToken = default) {}
+      public async ValueTask<int> ReadByteAsync(I2CAddress address, CancellationToken cancellationToken = default) {}
       public (IReadOnlySet<I2CAddress> WriteAddressSet, IReadOnlySet<I2CAddress> ReadAddressSet) ScanBus(I2CAddress addressRangeMin = default, I2CAddress addressRangeMax = default, IProgress<I2CScanBusProgress> progress = null, CancellationToken cancellationToken = default) {}
-      [AsyncStateMachine]
-      public ValueTask<(IReadOnlySet<I2CAddress> WriteAddressSet, IReadOnlySet<I2CAddress> ReadAddressSet)> ScanBusAsync(I2CAddress addressRangeMin = default, I2CAddress addressRangeMax = default, IProgress<I2CScanBusProgress> progress = null, CancellationToken cancellationToken = default) {}
+      public async ValueTask<(IReadOnlySet<I2CAddress> WriteAddressSet, IReadOnlySet<I2CAddress> ReadAddressSet)> ScanBusAsync(I2CAddress addressRangeMin = default, I2CAddress addressRangeMax = default, IProgress<I2CScanBusProgress> progress = null, CancellationToken cancellationToken = default) {}
       public void Write(I2CAddress address, ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default) {}
       public void Write(I2CAddress address, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-      [AsyncStateMachine]
-      public ValueTask WriteAsync(I2CAddress address, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
       public ValueTask WriteAsync(I2CAddress address, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public async ValueTask WriteAsync(I2CAddress address, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
       public void WriteByte(I2CAddress address, byte @value, CancellationToken cancellationToken = default) {}
-      [AsyncStateMachine]
-      public ValueTask WriteByteAsync(I2CAddress address, byte @value, CancellationToken cancellationToken = default) {}
+      public async ValueTask WriteByteAsync(I2CAddress address, byte @value, CancellationToken cancellationToken = default) {}
     }
 
     public const int DeviceProductID = 221;
@@ -156,38 +157,29 @@ namespace Smdn.Devices.MCP2221 {
     public const string HardwareRevisionMCP2221 = "A.6";
     public const string HardwareRevisionMCP2221A = "A.6";
 
+    public static MCP2221 Open(Func<IUsbHidDevice> createHidDevice, IServiceProvider serviceProvider = null) {}
+    public static MCP2221 Open(IServiceProvider serviceProvider = null) {}
+    public static MCP2221 Open(Predicate<IUsbHidDevice> findDevicePredicate, IServiceProvider serviceProvider = null) {}
+    public static ValueTask<MCP2221> OpenAsync(IServiceProvider serviceProvider = null) {}
+    public static ValueTask<MCP2221> OpenAsync(Predicate<IUsbHidDevice> findDevicePredicate, IServiceProvider serviceProvider = null) {}
+    public static async ValueTask<MCP2221> OpenAsync(Func<IUsbHidDevice> createHidDevice, IServiceProvider serviceProvider = null) {}
+
     public string ChipFactorySerialNumber { get; }
     public string FirmwareRevision { get; }
-    [Nullable(byte.MinValue)]
     public MCP2221.GP0Functionality GP0 { get; }
-    [Nullable(byte.MinValue)]
     public MCP2221.GP1Functionality GP1 { get; }
-    [Nullable(byte.MinValue)]
     public MCP2221.GP2Functionality GP2 { get; }
-    [Nullable(byte.MinValue)]
     public MCP2221.GP3Functionality GP3 { get; }
-    [Nullable(byte.MinValue)]
     public IReadOnlyList<MCP2221.GPFunctionality> GPs { get; }
     public string HardwareRevision { get; }
     public IUsbHidDevice HidDevice { get; }
-    [Nullable(byte.MinValue)]
     public MCP2221.I2CFunctionality I2C { get; }
     public string ManufacturerDescriptor { get; }
     public string ProductDescriptor { get; }
     public string SerialNumberDescriptor { get; }
 
     public void Dispose() {}
-    [AsyncStateMachine]
-    public ValueTask DisposeAsync() {}
-    public static MCP2221 Open(Func<IUsbHidDevice> createHidDevice, [Nullable(2)] IServiceProvider serviceProvider = null) {}
-    public static MCP2221 Open([Nullable(2)] IServiceProvider serviceProvider = null) {}
-    public static MCP2221 Open([Nullable] Predicate<IUsbHidDevice> findDevicePredicate, [Nullable(2)] IServiceProvider serviceProvider = null) {}
-    [AsyncStateMachine]
-    [return: Nullable] public static ValueTask<MCP2221> OpenAsync(Func<IUsbHidDevice> createHidDevice, [Nullable(2)] IServiceProvider serviceProvider = null) {}
-    [NullableContext(2)]
-    [return: Nullable] public static ValueTask<MCP2221> OpenAsync(IServiceProvider serviceProvider = null) {}
-    [NullableContext(2)]
-    [return: Nullable] public static ValueTask<MCP2221> OpenAsync([Nullable] Predicate<IUsbHidDevice> findDevicePredicate, IServiceProvider serviceProvider = null) {}
+    public async ValueTask DisposeAsync() {}
   }
 
   public readonly struct I2CAddress :
@@ -200,6 +192,16 @@ namespace Smdn.Devices.MCP2221 {
     public static readonly I2CAddress DeviceMinValue; // = "08"
     public static readonly I2CAddress Zero; // = "00"
 
+    public static bool operator == (I2CAddress x, I2CAddress y) {}
+    public static explicit operator byte(I2CAddress address) {}
+    public static explicit operator int(I2CAddress address) {}
+    public static bool operator > (I2CAddress left, I2CAddress right) {}
+    public static bool operator >= (I2CAddress left, I2CAddress right) {}
+    public static implicit operator I2CAddress(byte address) {}
+    public static bool operator != (I2CAddress x, I2CAddress y) {}
+    public static bool operator < (I2CAddress left, I2CAddress right) {}
+    public static bool operator <= (I2CAddress left, I2CAddress right) {}
+
     public I2CAddress(int address) {}
     public I2CAddress(int deviceAddressBits, int hardwareAddressBits) {}
 
@@ -210,15 +212,6 @@ namespace Smdn.Devices.MCP2221 {
     public override bool Equals(object obj) {}
     public override int GetHashCode() {}
     public override string ToString() {}
-    public static bool operator == (I2CAddress x, I2CAddress y) {}
-    public static explicit operator byte(I2CAddress address) {}
-    public static explicit operator int(I2CAddress address) {}
-    public static bool operator > (I2CAddress left, I2CAddress right) {}
-    public static bool operator >= (I2CAddress left, I2CAddress right) {}
-    public static implicit operator I2CAddress(byte address) {}
-    public static bool operator != (I2CAddress x, I2CAddress y) {}
-    public static bool operator < (I2CAddress left, I2CAddress right) {}
-    public static bool operator <= (I2CAddress left, I2CAddress right) {}
   }
 
   public readonly struct I2CScanBusProgress {
@@ -268,4 +261,5 @@ namespace Smdn.Devices.UsbHid {
     public UsbHidException(string message) {}
   }
 }
-
+// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.8.1.0.
+// Smdn.Reflection.ReverseGenerating.ListApi.Core v1.6.1.0 (https://github.com/smdn/Smdn.Reflection.ReverseGenerating)

--- a/doc/api-list/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221-net8.0.apilist.cs
@@ -2,8 +2,9 @@
 //   Name: Smdn.Devices.MCP2221
 //   AssemblyVersion: 0.9.4.0
 //   InformationalVersion: 0.9.4+bcf0f60c80f47181419bd376632a2c0be172ac98
-//   TargetFramework: .NETStandard,Version=v2.1
+//   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
+//   Metadata: IsTrimmable=True
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.MCP2221
 //   Metadata: RepositoryBranch=main
 //   Metadata: RepositoryCommit=bcf0f60c80f47181419bd376632a2c0be172ac98
@@ -11,8 +12,13 @@
 //     HidSharp, Version=2.1.0.0, Culture=neutral
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     System.Collections, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Device.Gpio, Version=1.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
-//     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Linq, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Memory, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Threading.Thread, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 
 using System;
 using System.Collections.Generic;
@@ -134,8 +140,8 @@ namespace Smdn.Devices.MCP2221 {
       public async ValueTask<int> ReadAsync(I2CAddress address, Memory<byte> buffer, CancellationToken cancellationToken = default) {}
       public int ReadByte(I2CAddress address, CancellationToken cancellationToken = default) {}
       public async ValueTask<int> ReadByteAsync(I2CAddress address, CancellationToken cancellationToken = default) {}
-      public (IReadOnlyCollection<I2CAddress> WriteAddressSet, IReadOnlyCollection<I2CAddress> ReadAddressSet) ScanBus(I2CAddress addressRangeMin = default, I2CAddress addressRangeMax = default, IProgress<I2CScanBusProgress> progress = null, CancellationToken cancellationToken = default) {}
-      public async ValueTask<(IReadOnlyCollection<I2CAddress> WriteAddressSet, IReadOnlyCollection<I2CAddress> ReadAddressSet)> ScanBusAsync(I2CAddress addressRangeMin = default, I2CAddress addressRangeMax = default, IProgress<I2CScanBusProgress> progress = null, CancellationToken cancellationToken = default) {}
+      public (IReadOnlySet<I2CAddress> WriteAddressSet, IReadOnlySet<I2CAddress> ReadAddressSet) ScanBus(I2CAddress addressRangeMin = default, I2CAddress addressRangeMax = default, IProgress<I2CScanBusProgress> progress = null, CancellationToken cancellationToken = default) {}
+      public async ValueTask<(IReadOnlySet<I2CAddress> WriteAddressSet, IReadOnlySet<I2CAddress> ReadAddressSet)> ScanBusAsync(I2CAddress addressRangeMin = default, I2CAddress addressRangeMax = default, IProgress<I2CScanBusProgress> progress = null, CancellationToken cancellationToken = default) {}
       public void Write(I2CAddress address, ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default) {}
       public void Write(I2CAddress address, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
       public ValueTask WriteAsync(I2CAddress address, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #3](https://github.com/smdn/Smdn.Devices.MCP2221/actions/runs/21986717489).

# Release target
- package_target_tag: `new-release/main/Smdn.Devices.MCP2221-0.9.4`
- package_prevver_ref: `releases/Smdn.Devices.MCP2221-0.9.3`
- package_prevver_tag: `releases/Smdn.Devices.MCP2221-0.9.3`
- package_id: `Smdn.Devices.MCP2221`
- package_id_with_version: `Smdn.Devices.MCP2221-0.9.4`
- package_version: `0.9.4`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Devices.MCP2221-0.9.4-1770985445`
- release_tag: `releases/Smdn.Devices.MCP2221-0.9.4`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/b09652730fcb82a8ca8438f9a99ea413`](https://gist.github.com/smdn/b09652730fcb82a8ca8438f9a99ea413)
- artifact_name_nupkg: `Smdn.Devices.MCP2221.0.9.4.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Devices.MCP2221.latest.nuspec
+++ Smdn.Devices.MCP2221.0.9.4.nuspec
@@ -1,32 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Devices.MCP2221</id>
-    <version>0.9.3</version>
+    <version>0.9.4</version>
     <title>Smdn.Devices.MCP2221</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Devices.MCP2221.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://smdn.jp/electronics/libs/Smdn.Devices.MCP2221/</projectUrl>
-    <description>Smdn.Devices.MCP2221 is a .NET library for controlling MCP2221/MCP2221A USB2.0 to I2C/UART Protocol Converter with GPIO. This library enables you to control MCP2221/MCP2221A's GPIO, I2C interface, and other functionalities via USB-HID interface.</description>
-    <copyright>Copyright �  smdn</copyright>
+    <description>`Smdn.Devices.MCP2221` is a .NET library for the **Microchip Technology MCP2221 and MCP2221A, a USB2.0 to I2C/UART Protocol Converter with GPIO**. This library provides APIs that enable .NET applications to access the functions of the MCP2221/MCP2221A via the USB-HID interface.</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Devices.MCP2221/releases/tag/releases%2FSmdn.Devices.MCP2221-0.9.4</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp USB,USB-HID,MCP2221,MCP2221A,I2C,GPIO</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Devices.MCP2221" branch="main" commit="3968a13d13f49f54dd615bc0a80ddf4bd9d3ef84" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Devices.MCP2221" commit="bcf0f60c80f47181419bd376632a2c0be172ac98" />
     <dependencies>
-      <group targetFramework="net5.0">
-        <dependency id="HidSharp" version="2.1.0" exclude="Build,Analyzers" />
+      <group targetFramework="net8.0">
+        <dependency id="HidSharp" version="[2.1.0, 3.0.0)" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.DependencyInjection" version="5.0.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
-        <dependency id="System.Device.Gpio" version="[1.4.0, 2.0.0)" exclude="Build,Analyzers" />
+        <dependency id="System.Device.Gpio" version="[1.4.0, 5.0.0)" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net10.0">
+        <dependency id="HidSharp" version="[2.1.0, 3.0.0)" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.DependencyInjection" version="5.0.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Device.Gpio" version="[1.4.0, 5.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
-        <dependency id="HidSharp" version="2.1.0" exclude="Build,Analyzers" />
+        <dependency id="HidSharp" version="[2.1.0, 3.0.0)" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.DependencyInjection" version="5.0.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
-        <dependency id="System.Device.Gpio" version="[1.4.0, 2.0.0)" exclude="Build,Analyzers" />
+        <dependency id="System.Device.Gpio" version="[1.4.0, 4.0.0)" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/src/Smdn.Devices.MCP2221/bin/Release/net10.0/Smdn.Devices.MCP2221.dll" target="lib/net10.0/Smdn.Devices.MCP2221.dll" />
+    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/src/Smdn.Devices.MCP2221/bin/Release/net10.0/Smdn.Devices.MCP2221.xml" target="lib/net10.0/Smdn.Devices.MCP2221.xml" />
+    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/src/Smdn.Devices.MCP2221/bin/Release/net8.0/Smdn.Devices.MCP2221.dll" target="lib/net8.0/Smdn.Devices.MCP2221.dll" />
+    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/src/Smdn.Devices.MCP2221/bin/Release/net8.0/Smdn.Devices.MCP2221.xml" target="lib/net8.0/Smdn.Devices.MCP2221.xml" />
+    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/src/Smdn.Devices.MCP2221/bin/Release/netstandard2.1/Smdn.Devices.MCP2221.dll" target="lib/netstandard2.1/Smdn.Devices.MCP2221.dll" />
+    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/src/Smdn.Devices.MCP2221/bin/Release/netstandard2.1/Smdn.Devices.MCP2221.xml" target="lib/netstandard2.1/Smdn.Devices.MCP2221.xml" />
+    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/.nuget/packages/smdn.msbuild.projectassets.common/1.6.2/project/images/package-icon.png" target="Smdn.Devices.MCP2221.png" />
+    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.Devices.MCP2221/Smdn.Devices.MCP2221/src/Smdn.Devices.MCP2221/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

