### PR TITLE
Add .NET Standard 2.0 to the target frameworks

### DIFF
--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.I2c/I2cOperationStateMachine.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.I2c/I2cOperationStateMachine.cs
@@ -5,14 +5,18 @@
 using System;
 using System.Collections.Generic;
 using System.Device.Gpio;
+#if NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES
 using System.Diagnostics.CodeAnalysis;
+#endif
 
 using Microsoft.Extensions.Logging;
 
 namespace Smdn.Devices.Mcp2221A.Peripherals.I2c;
 
 internal class I2cOperationStateMachine {
+#if NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES
   [DoesNotReturn]
+#endif
   private static OperationState ThrowUnexpectedResponseException(I2cAddress? address, byte response)
   {
     if (address.HasValue)
@@ -21,11 +25,15 @@ internal class I2cOperationStateMachine {
       throw new Mcp2221ACommandException($"unexpected response (0x{response:X2})");
   }
 
+#if NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES
   [DoesNotReturn]
+#endif
   private static OperationState ThrowI2cErrorException(I2cAddress address, byte? stateValue, string message, string? i2cEngineState = null)
     => throw new I2cCommandException(address, $"{message} (0x{stateValue?.ToString("X2", provider: null) ?? "??"}, {i2cEngineState ?? "(details not available)"})");
 
+#if NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES
   [DoesNotReturn]
+#endif
   private static OperationState ThrowUnknownEngineStateException(I2cAddress address, byte? stateValue, string? i2cEngineState = null)
     => throw new I2cCommandException(address, $"unknown I2C engine state (0x{stateValue?.ToString("X2", provider: null) ?? "??"}, {i2cEngineState ?? "(details not available)"})");
 

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.csproj
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.csproj
@@ -4,12 +4,13 @@ SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net8.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix>preview1</VersionSuffix>
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <IsAotCompatible>false</IsAotCompatible>
     <NoWarn>CS1591;$(NoWarn)</NoWarn> <!-- CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member' -->
+    <AllowUnsafeBlocks Condition="'$(TargetFramework)' == 'netstandard2.0'">true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Label="package properties">

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221AInfo.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221AInfo.cs
@@ -44,8 +44,13 @@ public sealed class Mcp2221AInfo : IMcp2221AInfo {
         string.Create(3, resp, (str, re) => {str[0] = (char)re[46]; str[1] = '.'; str[2] = (char)re[47]; }),
         string.Create(3, resp, (str, re) => {str[0] = (char)re[48]; str[1] = '.'; str[2] = (char)re[49]; })
 #endif
+#if SYSTEM_STRING_CREATE
         string.Create(3, ((char)resp[46], (char)resp[47]), CreateRevisionString),
         string.Create(3, ((char)resp[48], (char)resp[49]), CreateRevisionString)
+#else
+        new string(new[] { (char)resp[46], '.', (char)resp[47] }),
+        new string(new[] { (char)resp[48], '.', (char)resp[49] })
+#endif
       );
     }
   }
@@ -91,7 +96,15 @@ public sealed class Mcp2221AInfo : IMcp2221AInfo {
           serialNumberChars[i] = (char)resp[4 + i];
         }
 
+#if SYSTEM_STRING_CTOR_READONLYSPAN_OF_CHAR
         return new string(serialNumberChars);
+#else
+        unsafe {
+          fixed (char* ptr = serialNumberChars) {
+            return new string(ptr, 0, serialNumberChars.Length);
+          }
+        }
+#endif
       }
       else {
         // 0x02: The number of bytes + 2 in the provided USB Manufacturer/Product/Serial Number Descriptor String.
@@ -107,7 +120,15 @@ public sealed class Mcp2221AInfo : IMcp2221AInfo {
           descriptorStringChars[i] = (char)(lower | (higher << 8));
         }
 
+#if SYSTEM_STRING_CTOR_READONLYSPAN_OF_CHAR
         return new string(descriptorStringChars);
+#else
+        unsafe {
+          fixed (char* ptr = descriptorStringChars) {
+            return new string(ptr, 0, descriptorStringChars.Length);
+          }
+        }
+#endif
       }
     }
   }

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Tests.csproj
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Tests.csproj
@@ -10,6 +10,16 @@ SPDX-License-Identifier: MIT
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">net462;net481;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Suppress warning from Microsoft.Extensions.Diagnostics.Testing:
+      Microsoft.Extensions.Diagnostics.Testing 10.4.0 doesn't support net4xy and has not been tested with it.
+    -->
+    <SuppressTfmSupportBuildWarnings
+      Condition="$(TargetFramework.StartsWith('net4'))"
+    >true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.4.0"/>
   </ItemGroup>

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Tests.csproj
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet100)' == 'true' ">net10.0;$(TargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet80)' == 'true' ">net8.0;$(TargetFrameworks)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">net462;net481;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221A.I2c.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221A.I2c.cs
@@ -31,7 +31,18 @@ partial class Mcp2221ATests {
 
       foreach (var sequence in responseSequences) {
         endpoint.ReadStream.WriteByte(ReportInput);
-        endpoint.ReadStream.Write(ToByteArray(sequence));
+
+        var sequenceBytes = ToByteArray(sequence);
+
+        endpoint.ReadStream.Write(
+#if SYSTEM_IO_STREAM_WRITE_READONLYSPAN_OF_BYTE
+          sequenceBytes
+#else
+          sequenceBytes,
+          0,
+          sequenceBytes.Length
+#endif
+        );
       }
 
       endpoint.ReadStream.Position = currentPosition;

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221A.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221A.cs
@@ -16,6 +16,8 @@ namespace Smdn.Devices.Mcp2221A;
 public partial class Mcp2221ATests {
   private const byte ReportInput = 0x00;
   private const byte ReportOutput = 0x00;
+  private const int CommandLength = 64;
+  private const int ReportLength = 1 + CommandLength;
 
   internal const string DefaultManufacturer = "Microchip Technology Inc.";
   internal const string DefaultProduct = "MCP2221 USB-I2C/UART Combo";
@@ -40,48 +42,117 @@ public partial class Mcp2221ATests {
       productName: product,
       manufacturer: manufacturer,
       serialNumber: serialNumber,
-      createWriteStream: () => new MemoryStream(capacity: (1 + 64) * 5),
+      createWriteStream: () => new MemoryStream(capacity: ReportLength * 5),
       createReadStream: () => {
-        var readStream = new MemoryStream(capacity: (1 + 64) * 5);
+        var readStream = new MemoryStream(capacity: ReportLength * 5);
 
-        readStream.Write([
+        readStream.Write(
           // [MCP2221A] 3.1.1 STATUS/SET PARAMETERS
-          ReportInput, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x03, 0x00, 0x03, 0x14, 0x00, 0x40, 0x00, 0x10, 0x28, 0x00, 0x60, 0x01, 0x01, 0x00, 0x00, 0xF1, 0x79, 0xF0, 0x00, 0x00, 0x00, 0x30, 0x30, 0x0B, 0x30, 0x14, 0x23, 0x17, 0x7D, 0x06, 0x00, 0x00, 0x26, 0x94, 0x14, hardwareRevisionMajor, hardwareRevisionMinor, firmwareRevisionMajor, firmwareRevisionMinor, 0xFB, 0x03, 0x00, 0x00, 0xFA, 0x03, 0x76, 0x03, 0x5B, 0x02, 0x00, 0x00, 0x00, 0x00,
-        ]);
+          [ReportInput, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x03, 0x00, 0x03, 0x14, 0x00, 0x40, 0x00, 0x10, 0x28, 0x00, 0x60, 0x01, 0x01, 0x00, 0x00, 0xF1, 0x79, 0xF0, 0x00, 0x00, 0x00, 0x30, 0x30, 0x0B, 0x30, 0x14, 0x23, 0x17, 0x7D, 0x06, 0x00, 0x00, 0x26, 0x94, 0x14, hardwareRevisionMajor, hardwareRevisionMinor, firmwareRevisionMajor, firmwareRevisionMinor, 0xFB, 0x03, 0x00, 0x00, 0xFA, 0x03, 0x76, 0x03, 0x5B, 0x02, 0x00, 0x00, 0x00, 0x00]
+#if !SYSTEM_IO_STREAM_WRITE_READONLYSPAN_OF_BYTE
+          ,
+          0,
+          ReportLength
+#endif
+        );
 
         const int DescriptorOffset = 2;
 
         var manufacturerDescriptor = new byte[64 - 4];
-        var manufacturerDescriptorLength = (byte)Encoding.Unicode.GetBytes(manufacturer, manufacturerDescriptor);
+        var manufacturerDescriptorLength = (byte)Encoding.Unicode.GetBytes(
+#if SYSTEM_TEXT_ENCODING_GETBYTES_READONLYSPAN_OF_CHAR
+          manufacturer,
+          manufacturerDescriptor
+#else
+          manufacturer,
+          0,
+          manufacturer.Length,
+          manufacturerDescriptor,
+          0
+#endif
+        );
 
-        readStream.Write([
+        readStream.Write(
           // [MCP2221A] 3.1.2 READ FLASH DATA - TABLE 3-7 RESPONSE STRUCTURE - READ USB MANUFACTURER DESCRIPTOR STRING SUB-COMMAND
-          ReportInput, 0xB0, 0x00, (byte)(DescriptorOffset + manufacturerDescriptorLength), 0x03, .. manufacturerDescriptor
-        ]);
+          [ReportInput, 0xB0, 0x00, (byte)(DescriptorOffset + manufacturerDescriptorLength), 0x03, .. manufacturerDescriptor]
+#if !SYSTEM_IO_STREAM_WRITE_READONLYSPAN_OF_BYTE
+          ,
+          0,
+          ReportLength
+#endif
+        );
 
         var productDescriptor = new byte[64 - 4];
-        var productDescriptorLength = Encoding.Unicode.GetBytes(product, productDescriptor);
+        var productDescriptorLength = Encoding.Unicode.GetBytes(
+#if SYSTEM_TEXT_ENCODING_GETBYTES_READONLYSPAN_OF_CHAR
+          product,
+          productDescriptor
+#else
+          product,
+          0,
+          product.Length,
+          productDescriptor,
+          0
+#endif
+        );
 
-        readStream.Write([
+        readStream.Write(
           // [MCP2221A] 3.1.2 READ FLASH DATA - TABLE 3-8 RESPONSE STRUCTURE - READ USB PRODUCT DESCRIPTOR STRING SUB-COMMAND
-          ReportInput, 0xB0, 0x00, (byte)(DescriptorOffset + productDescriptorLength), 0x03, .. productDescriptor
-        ]);
+          [ReportInput, 0xB0, 0x00, (byte)(DescriptorOffset + productDescriptorLength), 0x03, .. productDescriptor]
+#if !SYSTEM_IO_STREAM_WRITE_READONLYSPAN_OF_BYTE
+          ,
+          0,
+          ReportLength
+#endif
+        );
 
         var serialNumberDescriptor = new byte[64 - 4];
-        var serialNumberDescriptorLength = Encoding.Unicode.GetBytes(serialNumber, serialNumberDescriptor);
+        var serialNumberDescriptorLength = Encoding.Unicode.GetBytes(
+#if SYSTEM_TEXT_ENCODING_GETBYTES_READONLYSPAN_OF_CHAR
+          serialNumber,
+          serialNumberDescriptor
+#else
+          serialNumber,
+          0,
+          serialNumber.Length,
+          serialNumberDescriptor,
+          0
+#endif
+        );
 
-        readStream.Write([
+        readStream.Write(
           // [MCP2221A] 3.1.2 READ FLASH DATA - TABLE 3-9 RESPONSE STRUCTURE - READ USB SERIAL NUMBER DESCRIPTOR STRING SUB-COMMAND
-          ReportInput, 0xB0, 0x00, (byte)(DescriptorOffset + serialNumberDescriptorLength), 0x03, .. serialNumberDescriptor
-        ]);
+          [ReportInput, 0xB0, 0x00, (byte)(DescriptorOffset + serialNumberDescriptorLength), 0x03, .. serialNumberDescriptor]
+#if !SYSTEM_IO_STREAM_WRITE_READONLYSPAN_OF_BYTE
+          ,
+          0,
+          ReportLength
+#endif
+        );
 
         var chipFactorySerialNumberDescriptor = new byte[64 - 4];
-        var chipFactorySerialNumberDescriptorLength = Encoding.ASCII.GetBytes(chipFactorySerialNumber, chipFactorySerialNumberDescriptor);
+        var chipFactorySerialNumberDescriptorLength = Encoding.ASCII.GetBytes(
+#if SYSTEM_TEXT_ENCODING_GETBYTES_READONLYSPAN_OF_CHAR
+          chipFactorySerialNumber,
+          chipFactorySerialNumberDescriptor
+#else
+          chipFactorySerialNumber,
+          0,
+          chipFactorySerialNumber.Length,
+          chipFactorySerialNumberDescriptor,
+          0
+#endif
+        );
 
-        readStream.Write([
+        readStream.Write(
           // [MCP2221A] 3.1.2 READ FLASH DATA - TABLE 3-10 RESPONSE STRUCTURE - READ CHIP FACTORY SERIAL NUMBER SUB-COMMAND
-          ReportInput, 0xB0, 0x00, (byte)chipFactorySerialNumberDescriptorLength, 0x00, .. chipFactorySerialNumberDescriptor
-        ]);
+          [ReportInput, 0xB0, 0x00, (byte)chipFactorySerialNumberDescriptorLength, 0x00, .. chipFactorySerialNumberDescriptor]
+#if !SYSTEM_IO_STREAM_WRITE_READONLYSPAN_OF_BYTE
+          ,
+          0,
+          ReportLength
+#endif
+        );
 
         readStream.Position = 0L;
 

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.IO.UsbHid/PseudoUsbHidDevice.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.IO.UsbHid/PseudoUsbHidDevice.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 using System;
+#if NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES
 using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,25 +25,33 @@ class PseudoUsbHidDevice : IUsbHidDevice {
   private readonly string? serialNumber;
 
   public bool TryGetProductName(
+#if NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES
     [NotNullWhen(true)]
+#endif
     out string? productName
   )
     => (productName = this.productName) is not null;
 
   public bool TryGetManufacturer(
+#if NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES
     [NotNullWhen(true)]
+#endif
     out string? manufacturer
   )
     => (manufacturer = this.manufacturer) is not null;
 
   public bool TryGetSerialNumber(
+#if NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES
     [NotNullWhen(true)]
+#endif
     out string? serialNumber
   )
     => (serialNumber = this.serialNumber) is not null;
 
   public bool TryGetDeviceIdentifier(
+#if NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES
     [NotNullWhen(true)]
+#endif
     out string? deviceIdentifier
   )
     => (deviceIdentifier = "/dev/null") is not null;

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.IO.UsbHid/PseudoUsbHidEndPoint.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.IO.UsbHid/PseudoUsbHidEndPoint.cs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 using System;
+using System.Buffers;
+#if SYSTEM_DIAGNOSTICS_CODEANALYSIS_MEMBERNOTNULLWHENATTRIBUTE
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +15,14 @@ namespace Smdn.IO.UsbHid;
 class PseudoUsbHidEndPoint : IUsbHidEndPoint {
   public IUsbHidDevice Device { get; private set; }
 
+#if SYSTEM_DIAGNOSTICS_CODEANALYSIS_MEMBERNOTNULLWHENATTRIBUTE
+  [MemberNotNullWhen(true, nameof(WriteStream))]
+#endif
   public bool CanWrite => WriteStream is not null;
+
+#if SYSTEM_DIAGNOSTICS_CODEANALYSIS_MEMBERNOTNULLWHENATTRIBUTE
+  [MemberNotNullWhen(true, nameof(ReadStream))]
+#endif
   public bool CanRead => ReadStream is not null;
 
   public Stream? WriteStream { get; private set; }
@@ -52,12 +63,20 @@ class PseudoUsbHidEndPoint : IUsbHidEndPoint {
   public async ValueTask DisposeAsync()
   {
     if (WriteStream is not null) {
+#if SYSTEM_IO_STREAM_DISPOSEASYNC
       await WriteStream.DisposeAsync();
+#else
+      WriteStream.Dispose();
+#endif
       WriteStream = null;
     }
 
     if (ReadStream is not null) {
+#if SYSTEM_IO_STREAM_DISPOSEASYNC
       await ReadStream.DisposeAsync();
+#else
+      ReadStream.Dispose();
+#endif
       ReadStream = null;
     }
 
@@ -71,27 +90,85 @@ class PseudoUsbHidEndPoint : IUsbHidEndPoint {
   {
     OnWritingAction?.Invoke();
 
-    (WriteStream ?? throw new InvalidOperationException("not writable")).Write(buffer);
+    if (!CanWrite)
+      throw new InvalidOperationException("not writable");
+
+#if SYSTEM_IO_STREAM_WRITE_READONLYSPAN_OF_BYTE
+    WriteStream.Write(buffer);
+#else
+    WriteStream!.Write(buffer.ToArray(), 0, buffer.Length);
+#endif
   }
 
   public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
   {
     OnWritingAction?.Invoke();
 
-    return (WriteStream ?? throw new InvalidOperationException("not writable")).WriteAsync(buffer, cancellationToken);
+    if (!CanWrite)
+      throw new InvalidOperationException("not writable");
+
+#if SYSTEM_IO_STREAM_WRITEASYNC_READONLYMEMORY_OF_BYTE
+    return WriteStream.WriteAsync(buffer, cancellationToken);
+#else
+    return WriteAsyncCore(WriteStream!, buffer, cancellationToken);
+
+    static async ValueTask WriteAsyncCore(Stream stream, ReadOnlyMemory<byte> buf, CancellationToken ct)
+      => await stream.WriteAsync(buf.ToArray(), 0, buf.Length, ct).ConfigureAwait(false);
+#endif
   }
 
   public int Read(Span<byte> buffer, CancellationToken cancellationToken = default)
   {
     OnReadingAction?.Invoke();
 
-    return (ReadStream ?? throw new InvalidOperationException("not readable")).Read(buffer);
+    if (!CanRead)
+      throw new InvalidOperationException("not readable");
+
+#if SYSTEM_IO_STREAM_READ_SPAN_OF_BYTE
+    return ReadStream.Read(buffer);
+#else
+    var temp = ArrayPool<byte>.Shared.Rent(buffer.Length);
+
+    try {
+      var ret = ReadStream!.Read(temp, 0, buffer.Length);
+
+      temp.AsSpan(0, ret).CopyTo(buffer);
+
+      return ret;
+    }
+    finally {
+      ArrayPool<byte>.Shared.Return(temp);
+    }
+#endif
   }
 
   public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
   {
     OnReadingAction?.Invoke();
 
-    return (ReadStream ?? throw new InvalidOperationException("not readable")).ReadAsync(buffer, cancellationToken);
+    if (!CanRead)
+      throw new InvalidOperationException("not readable");
+
+#if SYSTEM_IO_STREAM_READASYNC_MEMORY_OF_BYTE
+    return ReadStream.ReadAsync(buffer, cancellationToken);
+#else
+    return ReadAsyncCore(ReadStream!, buffer, cancellationToken);
+
+    static async ValueTask<int> ReadAsyncCore(Stream stream, Memory<byte> buf, CancellationToken ct)
+    {
+      var temp = ArrayPool<byte>.Shared.Rent(buf.Length);
+
+      try {
+        var ret = await stream.ReadAsync(temp, 0, buf.Length, ct).ConfigureAwait(false);
+
+        temp.AsMemory(0, ret).CopyTo(buf);
+
+        return ret;
+      }
+      finally {
+        ArrayPool<byte>.Shared.Return(temp);
+      }
+    }
+#endif
   }
 }

--- a/tests/TargetFrameworks.props
+++ b/tests/TargetFrameworks.props
@@ -1,55 +1,18 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2022 smdn <smdn@smdn.jp>
 SPDX-License-Identifier: MIT
 -->
 <Project>
   <PropertyGroup>
-    <!-- enable target framework net* (.NET >= 5.0) by default -->
+    <!-- enable target framework net*.0 (.NET >= 5.0) by default -->
     <EnableTargetFrameworkDotNet>true</EnableTargetFrameworkDotNet>
     <EnableTargetFrameworkDotNet100>true</EnableTargetFrameworkDotNet100>
     <EnableTargetFrameworkDotNet80>true</EnableTargetFrameworkDotNet80>
-    <!-- enable target framework net* (.NET Framework/Mono) by default -->
-    <EnableTargetFrameworkNetFx>true</EnableTargetFrameworkNetFx>
-  </PropertyGroup>
-
-  <!--
-    Note: RuntimeInformation.RuntimeIdentifier on >= .NET 8 has been changed to return 'linux-x64' instead of 'ubuntu.20.04-x64'.
-    RuntimeInformation.OSDescription still returns 'Ubuntu 22.04' on >= .NET 8.
-  -->
-
-  <!-- On Ubuntu 22.04 -->
-  <PropertyGroup
-    Condition="
-      $([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier.StartsWith('ubuntu.22.04')) or
-      $([System.Runtime.InteropServices.RuntimeInformation]::OSDescription.StartsWith('Ubuntu 22.04'))
-    "
-  >
-    <!-- disable Mono (test runner not working on local environment?) -->
-    <EnableTargetFrameworkNetFx Condition=" '$(GITHUB_ACTIONS)' != 'true' ">false</EnableTargetFrameworkNetFx>
-  </PropertyGroup>
-
-  <!-- On Ubuntu 24.04 -->
-  <PropertyGroup
-    Condition="
-      $([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier.StartsWith('ubuntu.24.04')) or
-      $([System.Runtime.InteropServices.RuntimeInformation]::OSDescription.StartsWith('Ubuntu 24.04'))
-    "
-  >
-    <!-- disable Mono on GitHub Actions Ubuntu 24.04 runner images -->
-    <EnableTargetFrameworkNetFx Condition=" '$(GITHUB_ACTIONS)' == 'true' ">false</EnableTargetFrameworkNetFx>
-  </PropertyGroup>
-
-  <!-- On MacOS (arm64) -->
-  <PropertyGroup
-    Condition="
-      $([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier.StartsWith('osx-arm64')) or
-      (
-        $([System.OperatingSystem]::IsMacOS()) and
-        $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.StartsWith('Arm64'))
-      )
-    "
-  >
-    <!-- disable Mono on GitHub Actions osx-arm64 runner images -->
-    <EnableTargetFrameworkNetFx Condition=" '$(GITHUB_ACTIONS)' == 'true' ">false</EnableTargetFrameworkNetFx>
+    <!-- disable target framework net4xy (.NET Framework/Mono) by default -->
+    <EnableTargetFrameworkNetFx>false</EnableTargetFrameworkNetFx>
+    <!-- enable target framework net4xy (.NET Framework) on Windows -->
+    <EnableTargetFrameworkNetFx
+      Condition="$([MSBuild]::IsOSPlatform('Windows'))"
+    >true</EnableTargetFrameworkNetFx>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Description
This PR extends the `TargetFrameworks` to include .NET Standard 2.0.
As a result, the library now supports .NET Framework 4.x, consistent with the `Smdn.IO.UsbHid.*` packages.

### Testing
Because the current test environment based on `Microsoft.Testing.Platform` appears to have insufficient support on Mono, the tests are executed only on Windows for now. Consequently, the test project targets the minimum supported `net462` and the latest `net481`.
