### PR TITLE
Improve verification of reports read from USB HID endpoints

### DIFF
--- a/examples/Smdn.Devices.Mcp2221A/GettingStarted/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/GettingStarted/Program.csproj
@@ -26,12 +26,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/I2CAdapter_BME280/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/I2CAdapter_BME280/Program.csproj
@@ -21,12 +21,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/I2CAdapter_HT16K33_4Digit14SegmentDisplay/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/I2CAdapter_HT16K33_4Digit14SegmentDisplay/Program.csproj
@@ -22,12 +22,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/I2CAdapter_MCP23017/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/I2CAdapter_MCP23017/Program.csproj
@@ -21,12 +21,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/I2CAdapter_US2066_SO1602A/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/I2CAdapter_US2066_SO1602A/Program.csproj
@@ -20,12 +20,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/SelectDevice/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/SelectDevice/Program.csproj
@@ -26,12 +26,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/blink-csharp/blink.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/blink-csharp/blink.csproj
@@ -20,12 +20,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/blink-visualbasic/blink.vbproj
+++ b/examples/Smdn.Devices.Mcp2221A/blink-visualbasic/blink.vbproj
@@ -20,12 +20,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/i2cscanbus/i2cscanbus.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/i2cscanbus/i2cscanbus.csproj
@@ -21,12 +21,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/logging/logging.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/logging/logging.csproj
@@ -21,12 +21,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/read-gpio/read-gpio.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/read-gpio/read-gpio.csproj
@@ -21,12 +21,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/shiftregister/shiftregister.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/shiftregister/shiftregister.csproj
@@ -20,12 +20,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
     -->
   </ItemGroup>
 

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221ATransceiver.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221ATransceiver.cs
@@ -18,14 +18,31 @@ using Smdn.IO.UsbHid;
 namespace Smdn.Devices.Mcp2221A;
 
 internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
+  private const int LengthOfReportId = 1;
+
   private const int CommandLength = 64;
   private const int ResponseLength = 64;
-  private const int CommandReportLength = 1 + CommandLength;
-  private const int ResponseReportLength = 1 + ResponseLength;
+  private const int CommandReportLength = LengthOfReportId + CommandLength;
+  private const int ResponseReportLength = LengthOfReportId + ResponseLength;
 
   private static readonly EventId EventIdCommand = new(1, "sent command");
   private static readonly EventId EventIdResponse = new(2, "received response");
 
+  private static void VerifyResponseReport(
+    ReadOnlySpan<byte> command,
+    ReadOnlySpan<byte> response
+  )
+  {
+    var commandCode = command[0];
+    var commandCodeEcho = response[0];
+
+    if (commandCode != commandCodeEcho)
+      throw new Mcp2221ACommandException($"The command echo in the received response does not match; command code '{commandCode:X2}' was expected, but the actual command echo was {commandCodeEcho:X2}.");
+  }
+
+  /*
+   * instance members
+   */
   private IUsbHidEndPoint? endPoint;
   public IUsbHidEndPoint EndPoint => endPoint ?? throw new ObjectDisposedException(GetType().FullName);
 
@@ -104,13 +121,15 @@ internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
 
       cancellationToken.ThrowIfCancellationRequested();
 
+      var commandSpan = commandReportMemory.Slice(LengthOfReportId, CommandLength).Span; // span except first byte (report IN)
+
       constructCommand(
-        commandReportMemory.Span.Slice(1, CommandLength),
+        commandSpan,
         userData.Span,
         arg
       );
 
-      logger?.LogTrace(EventIdCommand, "> " + ConvertByteSequenceToString(commandReportMemory.Span.Slice(1, CommandLength)));
+      logger?.LogTrace(EventIdCommand, "> " + ConvertByteSequenceToString(commandSpan));
 
       try {
         await
@@ -144,15 +163,16 @@ internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
         throw new Mcp2221ACommandException("reading response report failed", ex);
       }
 
-      logger?.LogTrace(EventIdResponse, "< " + ConvertByteSequenceToString(responseReportMemory.Span.Slice(1, ResponseLength)));
+      // recreate and reassign Span/ReadOnlySpan since they cannot cross await boundaries
+      commandSpan = commandReportMemory.Slice(LengthOfReportId, CommandLength).Span; // span except first byte (report IN)
 
-      if (commandReportMemory.Span[0] != responseReportMemory.Span[0])
-        throw new Mcp2221ACommandException($"unexpected command echo (command code: {commandReportMemory.Span[0]:X2}, command code echo: {responseReportMemory.Span[0]:X2})");
+      var responseSpan = responseReportMemory.Slice(LengthOfReportId, ResponseLength).Span; // span except first byte (report OUT)
 
-      return parseResponse(
-        responseReportMemory.Span.Slice(1, ResponseLength),
-        arg
-      );
+      logger?.LogTrace(EventIdResponse, "< " + ConvertByteSequenceToString(responseSpan));
+
+      VerifyResponseReport(commandSpan, responseSpan);
+
+      return parseResponse(responseSpan, arg);
     }
     finally {
       ArrayPool<byte>.Shared.Return(commandReport);
@@ -183,13 +203,16 @@ internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
 
     cancellationToken.ThrowIfCancellationRequested();
 
+    var commandSpan = commandReport.Slice(LengthOfReportId, CommandLength); // span except first byte (report IN)
+    var responseSpan = responseReport.Slice(LengthOfReportId, ResponseLength); // span except first byte (report OUT)
+
     constructCommand(
-      commandReport.Slice(1),
+      commandSpan,
       userData,
       arg
     );
 
-    logger?.LogTrace(EventIdCommand, "> " + ConvertByteSequenceToString(commandReport.Slice(1)));
+    logger?.LogTrace(EventIdCommand, "> " + ConvertByteSequenceToString(commandSpan));
 
     try {
 #if SYSTEM_DIAGNOSTICS_CODEANALYSIS_MEMBERNOTNULLATTRIBUTE
@@ -222,14 +245,10 @@ internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
       throw new Mcp2221ACommandException("reading response report failed", ex);
     }
 
-    logger?.LogTrace(EventIdResponse, "< " + ConvertByteSequenceToString(responseReport.Slice(1)));
+    logger?.LogTrace(EventIdResponse, "< " + ConvertByteSequenceToString(responseSpan));
 
-    if (commandReport[0] != responseReport[0])
-      throw new Mcp2221ACommandException($"unexpected command echo (command code: {commandReport[0]:X2}, command code echo: {responseReport[0]:X2})");
+    VerifyResponseReport(commandSpan, responseSpan);
 
-    return parseResponse(
-      responseReport.Slice(1),
-      arg
-    );
+    return parseResponse(responseSpan, arg);
   }
 }

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221ATransceiver.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221ATransceiver.cs
@@ -30,9 +30,13 @@ internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
 
   private static void VerifyResponseReport(
     ReadOnlySpan<byte> command,
-    ReadOnlySpan<byte> response
+    ReadOnlySpan<byte> response,
+    int actualResponseReportLength
   )
   {
+    if (actualResponseReportLength != ResponseReportLength)
+      throw new Mcp2221ACommandException($"The length of the received response report does not reach the expected length; expected {ResponseReportLength} bytes, but was actually {actualResponseReportLength} bytes.");
+
     var commandCode = command[0];
     var commandCodeEcho = response[0];
 
@@ -80,8 +84,18 @@ internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
     }
   }
 
-  private static string ConvertByteSequenceToString(ReadOnlySpan<byte> sequence)
+  private static string ConvertByteSequenceToString(
+    ReadOnlySpan<byte> sequence,
+    int? actualLength = default
+  )
   {
+    if (actualLength is int actualSequenceLength) {
+      if (actualSequenceLength <= 0)
+        return string.Empty;
+
+      sequence = sequence.Slice(0, actualSequenceLength);
+    }
+
     var buffer = ArrayPool<byte>.Shared.Rent(sequence.Length);
 
     try {
@@ -150,8 +164,10 @@ internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
         throw new Mcp2221ACommandException("writing command report failed", ex);
       }
 
+      int readReportLength = default;
+
       try {
-        await endPoint.ReadAsync(
+        readReportLength = await endPoint.ReadAsync(
           responseReportMemory,
           cancellationToken
         ).ConfigureAwait(false);
@@ -168,9 +184,12 @@ internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
 
       var responseSpan = responseReportMemory.Slice(LengthOfReportId, ResponseLength).Span; // span except first byte (report OUT)
 
-      logger?.LogTrace(EventIdResponse, "< " + ConvertByteSequenceToString(responseSpan));
+      logger?.LogTrace(
+        EventIdResponse,
+        "< " + ConvertByteSequenceToString(responseSpan, readReportLength - LengthOfReportId)
+      );
 
-      VerifyResponseReport(commandSpan, responseSpan);
+      VerifyResponseReport(commandSpan, responseSpan, readReportLength);
 
       return parseResponse(responseSpan, arg);
     }
@@ -232,8 +251,10 @@ internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
       throw new Mcp2221ACommandException("writing command report failed", ex);
     }
 
+    int readReportLength = default;
+
     try {
-      endPoint.Read(
+      readReportLength = endPoint.Read(
         responseReport,
         cancellationToken
       );
@@ -245,9 +266,12 @@ internal sealed class Mcp2221ATransceiver : IMcp2221ATransceiver, IDisposable {
       throw new Mcp2221ACommandException("reading response report failed", ex);
     }
 
-    logger?.LogTrace(EventIdResponse, "< " + ConvertByteSequenceToString(responseSpan));
+    logger?.LogTrace(
+      EventIdResponse,
+      "< " + ConvertByteSequenceToString(responseSpan, readReportLength - LengthOfReportId)
+    );
 
-    VerifyResponseReport(commandSpan, responseSpan);
+    VerifyResponseReport(commandSpan, responseSpan, readReportLength);
 
     return parseResponse(responseSpan, arg);
   }

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221A.I2c.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221A.I2c.cs
@@ -16,7 +16,7 @@ namespace Smdn.Devices.Mcp2221A;
 #pragma warning disable IDE0040
 partial class Mcp2221ATests {
 #pragma warning restore IDE0040
-  private static void AppendResponse(PseudoUsbHidEndPoint endPoint, params string[] responseSequences)
+  internal static void AppendResponse(PseudoUsbHidEndPoint endPoint, params string[] responseSequences)
   {
     static byte[] ToByteArray(string hexByteSequence)
       => hexByteSequence.Split('-').Select(hex => Convert.ToByte(hex, 16)).ToArray();

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221A.I2c.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221A.I2c.cs
@@ -19,7 +19,7 @@ partial class Mcp2221ATests {
   internal static void AppendResponse(PseudoUsbHidEndPoint endPoint, params string[] responseSequences)
   {
     static byte[] ToByteArray(string hexByteSequence)
-      => hexByteSequence.Split('-').Select(hex => Convert.ToByte(hex, 16)).ToArray();
+      => hexByteSequence.Length == 0 ? Array.Empty<byte>() : hexByteSequence.Split('-').Select(hex => Convert.ToByte(hex, 16)).ToArray();
 
     if (!endPoint.CanRead)
       throw new InvalidOperationException("endpoint does not support reading");

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221ATransceiver.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221ATransceiver.cs
@@ -6,6 +6,10 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+
 using NUnit.Framework;
 
 using Smdn.IO.UsbHid;
@@ -14,6 +18,8 @@ namespace Smdn.Devices.Mcp2221A;
 
 [TestFixture]
 public class Mcp2221ATransceiverTests {
+  private const int LengthOfReportId = 1;
+
   [Test]
   public void CommandAsync_UnexpectedCommandEcho()
     => CommandSyncOrAsync_UnexpectedCommandEcho(
@@ -58,6 +64,133 @@ public class Mcp2221ATransceiverTests {
         .With
         .Property(nameof(Mcp2221ACommandException.Message))
         .Contains($"{ResponseCommandCode:X2}")
+    );
+  }
+
+  [TestCase(0)]
+  [TestCase(1)]
+  [TestCase(63)]
+  public void CommandAsync_ResponseReportTooShort(int actualResponseLength)
+    => CommandSyncOrAsync_ResponseReportTooShort(
+      actualResponseLength: actualResponseLength,
+      static async mcp2221A => await mcp2221A.GP0.GetValueAsync().ConfigureAwait(false)
+    );
+
+  [TestCase(0)]
+  [TestCase(1)]
+  [TestCase(63)]
+  public void Command_ResponseReportTooShort(int actualResponseLength)
+    => CommandSyncOrAsync_ResponseReportTooShort(
+      actualResponseLength: actualResponseLength,
+      static mcp2221A => new(mcp2221A.GP0.GetValue())
+    );
+
+  private void CommandSyncOrAsync_ResponseReportTooShort(
+    int actualResponseLength,
+    Func<Mcp2221A, ValueTask<PinValue>> getGp0PinValueAsyncFunc
+  )
+  {
+    var loggerProvider = new FakeLoggerProvider();
+    var services = new ServiceCollection();
+
+    services.AddSingleton<ILoggerFactory>(new LoggerFactory([loggerProvider]));
+
+    using var serviceProvider = services.BuildServiceProvider();
+
+    using var mcp2221A = Mcp2221A.Create(
+      Mcp2221ATests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true,
+      serviceProvider: serviceProvider
+    );
+    var endPoint = (mcp2221A.HidDevice as PseudoUsbHidDevice)!.EndPoint;
+
+    // [MCP2221A] 3.1.12 GET GPIO VALUES
+    // [0] 0x51: Get GPIO Values command code
+    // [1] 0x00: Command completed successfully
+    // [2 + 2n] 0xEE: GP<n> is not set for GPIO operation
+    // [3 + 2n] 0xEF: GP<n> is not set for GPIO operation
+    // [10-63] Don't care
+    var getGpioValuesResponseBytes =
+      new byte[] { 0x51, 0x00, 0xEE, 0xEF, 0xEE, 0xEF, 0xEE, 0xEF, 0xEE, 0xEF }
+      .Concat(Enumerable.Repeat((byte)0x00, 64 - 10))
+      .ToArray();
+
+    // Assume a scenario where a response of 64 bytes is expected,
+    // but less than 64 bytes is returned.
+    Mcp2221ATests.AppendResponse(
+      endPoint,
+      BitConverter.ToString(getGpioValuesResponseBytes.Take(actualResponseLength).ToArray())
+    );
+
+    loggerProvider.Collector.Clear();
+
+    var actualReportLength = actualResponseLength + LengthOfReportId;
+
+    Assert.That(
+      async () => _ = await getGp0PinValueAsyncFunc(mcp2221A),
+      Throws
+        .TypeOf<Mcp2221ACommandException>()
+        .With
+        .Property(nameof(Mcp2221ACommandException.Message))
+        .Contains($"{actualReportLength} bytes")
+    );
+
+    Assert.That(
+      loggerProvider.Collector.Count,
+      Is.EqualTo(2),
+      "The sent command and received response should be logged."
+    );
+  }
+
+  [Test]
+  public void CommandAsync_ResponseReportTooShort_NoResponse()
+    => CommandSyncOrAsync_ResponseReportTooShort_NoResponse(
+      static async mcp2221A => await mcp2221A.GP0.GetValueAsync().ConfigureAwait(false)
+    );
+
+  [Test]
+  public void Command_ResponseReportTooShort_NoResponse()
+    => CommandSyncOrAsync_ResponseReportTooShort_NoResponse(
+      static mcp2221A => new(mcp2221A.GP0.GetValue())
+    );
+
+  private void CommandSyncOrAsync_ResponseReportTooShort_NoResponse(
+    Func<Mcp2221A, ValueTask<PinValue>> getGp0PinValueAsyncFunc
+  )
+  {
+    var loggerProvider = new FakeLoggerProvider();
+    var services = new ServiceCollection();
+
+    services.AddSingleton<ILoggerFactory>(new LoggerFactory([loggerProvider]));
+
+    using var serviceProvider = services.BuildServiceProvider();
+
+    using var mcp2221A = Mcp2221A.Create(
+      Mcp2221ATests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true,
+      serviceProvider: serviceProvider
+    );
+
+    // Assume a scenario where the report is not returned and
+    // the read result from the endpoint is empty.
+    // Mcp2221ATests.AppendResponse(...);
+    const int ActualReportLength = 0;
+
+    loggerProvider.Collector.Clear();
+
+    Assert.That(
+      async () => _ = await getGp0PinValueAsyncFunc(mcp2221A),
+      Throws
+        .TypeOf<Mcp2221ACommandException>()
+        .With
+        .Property(nameof(Mcp2221ACommandException.Message))
+        .Contains($"{ActualReportLength} bytes")
+    );
+
+    Assert.That(
+      loggerProvider.Collector.Count,
+      Is.EqualTo(2),
+      "The sent command and received response should be logged."
     );
   }
 }

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221ATransceiver.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221ATransceiver.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Device.Gpio;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using Smdn.IO.UsbHid;
+
+namespace Smdn.Devices.Mcp2221A;
+
+[TestFixture]
+public class Mcp2221ATransceiverTests {
+  [Test]
+  public void CommandAsync_UnexpectedCommandEcho()
+    => CommandSyncOrAsync_UnexpectedCommandEcho(
+      static async mcp2221A => await mcp2221A.GP0.GetValueAsync().ConfigureAwait(false)
+    );
+
+  [Test]
+  public void Command_UnexpectedCommandEcho()
+    => CommandSyncOrAsync_UnexpectedCommandEcho(
+      static mcp2221A => new(mcp2221A.GP0.GetValue())
+    );
+
+  private void CommandSyncOrAsync_UnexpectedCommandEcho(
+    Func<Mcp2221A, ValueTask<PinValue>> getGp0PinValueAsyncFunc
+  )
+  {
+    using var mcp2221A = Mcp2221A.Create(
+      Mcp2221ATests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true
+    );
+    var endPoint = (mcp2221A.HidDevice as PseudoUsbHidDevice)!.EndPoint;
+
+    // Assume a scenario where 0xFF is returned instead of the
+    // expected 0x51 for the 'Get GPIO Values' command code
+    const byte ResponseCommandCode = 0xFF;
+
+    Mcp2221ATests.AppendResponse(
+      endPoint,
+      // [MCP2221A] 3.1.12 GET GPIO VALUES
+      // [0] 0x51: Get GPIO Values command code
+      // [1] 0x00: Command completed successfully
+      // [2 + 2n] 0xEE: GP<n> is not set for GPIO operation
+      // [3 + 2n] 0xEF: GP<n> is not set for GPIO operation
+      // [10-63] Don't care
+      $"{ResponseCommandCode:X2}-00-EE-FF-EE-FF-EE-FF-EE-FF-" + string.Join("-", Enumerable.Repeat((byte)0x00, 64 - 10))
+    );
+
+    Assert.That(
+      async () => _ = await getGp0PinValueAsyncFunc(mcp2221A),
+      Throws
+        .TypeOf<Mcp2221ACommandException>()
+        .With
+        .Property(nameof(Mcp2221ACommandException.Message))
+        .Contains($"{ResponseCommandCode:X2}")
+    );
+  }
+}


### PR DESCRIPTION
### Description
This PR improves the verification of report data read by the `Mcp2221ATransceiver.Command`/`CommandAsync` methods.

Previously, the methods did not correctly verify whether the command code contained in the returned report matched the command code that had been sent. This PR resolves that issue.
In addition, this PR introduces verification of the report length. When the length does not match the expected value, the method now throws an exception.

This change addresses conditions that does not normally occur when using an actual MCP2221A and an actual USB HID backend.
However, when using a pseudo USB HID endpoint for testing, there is a possibility that the simulated responses or the test code contain mistakes.
Strengthening the verification helps reduce the risk of false negatives where tests pass unintentionally.

Related to this, both `Smdn.IO.UsbHid.Providers.LibUsbDotNet` and `Smdn.IO.UsbHid.Providers.LibUsbDotNetV3` have been updated to fix an issue where the report length did not include the length of report ID.
This PR also updates the dependencies to those corrected versions.
