### PR TITLE
Release main/Smdn.Devices.Mcp2221A-1.0.0-preview2

### DIFF
--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-net8.0.apilist.cs
@@ -1,20 +1,20 @@
-// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview1)
+// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview2)
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview1+077854654720e368ee674194833ee52d976ac129
+//   InformationalVersion: 1.0.0-preview2+9335bdfc1b937075a51ac35af5bd1768fa3a1654
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Metadata: IsTrimmable=True
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
-//   Metadata: RepositoryCommit=077854654720e368ee674194833ee52d976ac129
+//   Metadata: RepositoryCommit=9335bdfc1b937075a51ac35af5bd1768fa3a1654
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.IO.UsbHid.Abstractions, Version=1.0.0.0, Culture=neutral
 //     System.Collections, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-//     System.Device.Gpio, Version=1.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
+//     System.Device.Gpio, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
 //     System.Linq, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Memory, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
@@ -27,6 +27,7 @@ using System.Device.I2c;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.Devices.Mcp2221A;
+using Smdn.Devices.Mcp2221A.Peripherals.Gpio;
 using Smdn.Devices.Mcp2221A.Peripherals.I2c;
 using Smdn.IO.UsbHid;
 
@@ -40,6 +41,34 @@ namespace Smdn.Devices.Mcp2221A {
     string SerialNumber { get; }
   }
 
+  public static class IGpControllerGroupExtensions {
+    extension(IGpControllerGroup gpPins) {
+      public void ConfigureAllAsGpio(PinMode? gp0Mode = null, PinValue? gp0InitialValue = null, PinMode? gp1Mode = null, PinValue? gp1InitialValue = null, PinMode? gp2Mode = null, PinValue? gp2InitialValue = null, PinMode? gp3Mode = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAllAsGpioAsync(PinMode? gp0Mode = null, PinValue? gp0InitialValue = null, PinMode? gp1Mode = null, PinValue? gp1InitialValue = null, PinMode? gp2Mode = null, PinValue? gp2InitialValue = null, PinMode? gp3Mode = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default) {}
+      public void ConfigureAllAsGpioInput(CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAllAsGpioInputAsync(CancellationToken cancellationToken = default) {}
+      public void ConfigureAllAsGpioOutput(PinValue? gp0InitialValue = null, PinValue? gp1InitialValue = null, PinValue? gp2InitialValue = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAllAsGpioOutputAsync(PinValue? gp0InitialValue = null, PinValue? gp1InitialValue = null, PinValue? gp2InitialValue = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default) {}
+      public void ConfigureAllGpFunctions(GpFunction? gp0Function = null, GpFunction? gp1Function = null, GpFunction? gp2Function = null, GpFunction? gp3Function = null, CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAllGpFunctionsAsync(GpFunction? gp0Function = null, GpFunction? gp1Function = null, GpFunction? gp2Function = null, GpFunction? gp3Function = null, CancellationToken cancellationToken = default) {}
+      public (PinValue Gp0Value, PinValue Gp1Value, PinValue Gp2Value, PinValue Gp3Value) Read(CancellationToken cancellationToken = default) {}
+      public void Read(Span<PinValuePair> pinValuePairs, CancellationToken cancellationToken = default) {}
+      public ValueTask ReadAsync(Memory<PinValuePair> pinValuePairs, CancellationToken cancellationToken = default) {}
+      public ValueTask<(PinValue Gp0Value, PinValue Gp1Value, PinValue Gp2Value, PinValue Gp3Value)> ReadAsync(CancellationToken cancellationToken = default) {}
+      public void Write(PinValue? gp0Value = null, PinValue? gp1Value = null, PinValue? gp2Value = null, PinValue? gp3Value = null, CancellationToken cancellationToken = default) {}
+      public void Write(ReadOnlySpan<PinValuePair> pinValuePairs, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(PinValue? gp0Value = null, PinValue? gp1Value = null, PinValue? gp2Value = null, PinValue? gp3Value = null, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(ReadOnlyMemory<PinValuePair> pinValuePairs, CancellationToken cancellationToken = default) {}
+    }
+  }
+
+  public static class IGpioControllerExtensions {
+    public static void ConfigureAsGpioInput(this IGpioController controller, CancellationToken cancellationToken = default) {}
+    public static ValueTask ConfigureAsGpioInputAsync(this IGpioController controller, CancellationToken cancellationToken = default) {}
+    public static void ConfigureAsGpioOutput(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    public static ValueTask ConfigureAsGpioOutputAsync(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+  }
+
   public static class IMcp2221AInfoExtensions {
     extension(IMcp2221AInfo info) {
       public bool IsMcp2221A { get; }
@@ -51,58 +80,6 @@ namespace Smdn.Devices.Mcp2221A {
     IDisposable,
     IMcp2221AInfo
   {
-    public sealed class GP0Functionality : GPFunctionality {
-      public void ConfigureAsLedUrx(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsLedUrxAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsSspnd(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsSspndAsync(CancellationToken cancellationToken = default) {}
-    }
-
-    public sealed class GP1Functionality : GPFunctionality {
-      public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsClockOutput(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsClockOutputAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsInterruptDetection(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsInterruptDetectionAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsLedUtx(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsLedUtxAsync(CancellationToken cancellationToken = default) {}
-    }
-
-    public sealed class GP2Functionality : GPFunctionality {
-      public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsDac(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsDacAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsUsbCfg(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsUsbCfgAsync(CancellationToken cancellationToken = default) {}
-    }
-
-    public sealed class GP3Functionality : GPFunctionality {
-      public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsDac(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsDacAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsLedI2c(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsLedI2cAsync(CancellationToken cancellationToken = default) {}
-    }
-
-    public abstract class GPFunctionality {
-      public string? PinDesignation { get; }
-      public string PinName { get; }
-
-      public void ConfigureAsGpio(PinMode initialDirection = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsGpioAsync(PinMode initialDirection = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-      public PinMode GetDirection(CancellationToken cancellationToken = default) {}
-      public ValueTask<PinMode> GetDirectionAsync(CancellationToken cancellationToken = default) {}
-      public PinValue GetValue(CancellationToken cancellationToken = default) {}
-      public ValueTask<PinValue> GetValueAsync(CancellationToken cancellationToken = default) {}
-      public void SetDirection(PinMode newDirection, CancellationToken cancellationToken = default) {}
-      public ValueTask SetDirectionAsync(PinMode newDirection, CancellationToken cancellationToken = default) {}
-      public void SetValue(PinValue newValue, CancellationToken cancellationToken = default) {}
-      public ValueTask SetValueAsync(PinValue newValue, CancellationToken cancellationToken = default) {}
-    }
-
     public const int DefaultProductId = 221;
     public const int DefaultVendorId = 1240;
     public const string FirmwareRevisionMcp2221 = "1.1";
@@ -122,20 +99,15 @@ namespace Smdn.Devices.Mcp2221A {
     public static ValueTask<Mcp2221A> CreateAsync<TServiceKey>(IServiceProvider serviceProvider, TServiceKey serviceKey, CancellationToken cancellationToken = default) {}
     public static ValueTask<Mcp2221A> CreateAsync<TServiceKey>(IServiceProvider serviceProvider, TServiceKey serviceKey, Predicate<IUsbHidDevice>? usbHidDeviceFilter, Predicate<IMcp2221AInfo>? mcp2221AFilter, CancellationToken cancellationToken = default) {}
     public static ValueTask<Mcp2221A> CreateAsync<TServiceKey>(IUsbHidDevice usbHidDevice, IServiceProvider? serviceProvider, TServiceKey serviceKey, bool shouldDisposeUsbHidDevice = false, CancellationToken cancellationToken = default) {}
-    [Obsolete("Use Create with IUsbHidDevice instead.", true)]
-    public static Mcp2221A Open(Func<IUsbHidDevice?> createHidDevice, IServiceProvider? serviceProvider = null) {}
-    [Obsolete("Use CreateAsync with IUsbHidDevice instead.", true)]
-    public static async ValueTask<Mcp2221A> OpenAsync(Func<IUsbHidDevice?> createHidDevice, IServiceProvider? serviceProvider = null) {}
-    public static bool TryCalculateMcp2221AI2cSpeedDivider(int i2cBusSpeedInKbps, out byte i2cSpeedDivider) {}
-    public static bool TryCalculateMcp2221I2cSpeedDivider(int i2cBusSpeedInKbps, out byte i2cSpeedDivider) {}
 
     public string ChipFactorySerialNumber { get; }
     public string FirmwareRevision { get; }
-    public Mcp2221A.GP0Functionality GP0 { get; }
-    public Mcp2221A.GP1Functionality GP1 { get; }
-    public Mcp2221A.GP2Functionality GP2 { get; }
-    public Mcp2221A.GP3Functionality GP3 { get; }
-    public IReadOnlyList<Mcp2221A.GPFunctionality> GPs { get; }
+    public Gp0Controller GpPin0 { get; }
+    public Gp1Controller GpPin1 { get; }
+    public Gp2Controller GpPin2 { get; }
+    public Gp3Controller GpPin3 { get; }
+    public IGpControllerGroup GpPins { get; }
+    public GpioController GpioController { get; }
     public string HardwareRevision { get; }
     public IUsbHidDevice HidDevice { get; }
     public Mcp2221AI2cBus I2c { get; }
@@ -218,6 +190,137 @@ namespace Smdn.Devices.Mcp2221A {
     public byte ToByte() {}
     public int ToInt32() {}
     public override string ToString() {}
+  }
+
+  public readonly record struct PinModePair {
+    public PinModePair(int PinNumber, PinMode PinMode) {}
+
+    public PinMode PinMode { get; init; }
+    public int PinNumber { get; init; }
+
+    [CompilerGenerated]
+    public void Deconstruct(out int PinNumber, out PinMode PinMode) {}
+    [CompilerGenerated]
+    public override string ToString() {}
+  }
+}
+
+namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
+  public interface IGpControllerGroup : IReadOnlyList<GpController> {
+    Gp0Controller Gp0 { get; }
+    Gp1Controller Gp1 { get; }
+    Gp2Controller Gp2 { get; }
+    Gp3Controller Gp3 { get; }
+
+    void ApplyGpioStates(ReadOnlySpan<PinValuePair> pinValuePairs, ReadOnlySpan<PinModePair> pinModePairs, CancellationToken cancellationToken = default);
+    ValueTask ApplyGpioStatesAsync(ReadOnlyMemory<PinValuePair> pinValuePairs, ReadOnlyMemory<PinModePair> pinModePairs, CancellationToken cancellationToken = default);
+    void ConfigureAllGpSettings(GpFunction? gp0Function = null, PinMode? gp0Mode = null, PinValue? gp0InitialValue = null, GpFunction? gp1Function = null, PinMode? gp1Mode = null, PinValue? gp1InitialValue = null, GpFunction? gp2Function = null, PinMode? gp2Mode = null, PinValue? gp2InitialValue = null, GpFunction? gp3Function = null, PinMode? gp3Mode = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAllGpSettingsAsync(GpFunction? gp0Function = null, PinMode? gp0Mode = null, PinValue? gp0InitialValue = null, GpFunction? gp1Function = null, PinMode? gp1Mode = null, PinValue? gp1InitialValue = null, GpFunction? gp2Function = null, PinMode? gp2Mode = null, PinValue? gp2InitialValue = null, GpFunction? gp3Function = null, PinMode? gp3Mode = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default);
+    void FetchGpioStates(Span<PinValuePair> pinValuePairs, Span<PinModePair> pinModePairs, CancellationToken cancellationToken = default);
+    ValueTask FetchGpioStatesAsync(Memory<PinValuePair> pinValuePairs, Memory<PinModePair> pinModePairs, CancellationToken cancellationToken = default);
+  }
+
+  public interface IGpioController {
+    void ConfigureAsGpio(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsGpioAsync(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
+    PinMode GetMode(CancellationToken cancellationToken = default);
+    ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default);
+    PinValue Read(CancellationToken cancellationToken = default);
+    ValueTask<PinValue> ReadAsync(CancellationToken cancellationToken = default);
+    void SetMode(PinMode mode, CancellationToken cancellationToken = default);
+    ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default);
+    void Write(PinValue @value, CancellationToken cancellationToken = default);
+    ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default);
+  }
+
+  public enum GpFunction : int {
+    Adc = 1,
+    ClockOutput = 5,
+    Dac = 2,
+    ExternalInterrupt = 3,
+    Gpio = 0,
+    LedOutput = 4,
+    UsbConfigureStatus = 7,
+    UsbSuspendStatus = 6,
+  }
+
+  public sealed class Gp0Controller : GpController {
+    public override string CurrentDesignation { get; }
+    public override GpFunction CurrentFunction { get; }
+    public override int Index { get; }
+    public override string PinName { get; }
+
+    public void ConfigureAsUrxLedOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsUrxLedOutputAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsUsbSuspendStatus(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsUsbSuspendStatusAsync(CancellationToken cancellationToken = default) {}
+  }
+
+  public sealed class Gp1Controller : GpController {
+    public override string CurrentDesignation { get; }
+    public override GpFunction CurrentFunction { get; }
+    public override int Index { get; }
+    public override string PinName { get; }
+
+    public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsClockOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsClockOutputAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsExternalInterrupt(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsExternalInterruptAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsUtxLedOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsUtxLedOutputAsync(CancellationToken cancellationToken = default) {}
+  }
+
+  public sealed class Gp2Controller : GpController {
+    public override string CurrentDesignation { get; }
+    public override GpFunction CurrentFunction { get; }
+    public override int Index { get; }
+    public override string PinName { get; }
+
+    public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsUsbConfigureStatus(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsUsbConfigureStatusAsync(CancellationToken cancellationToken = default) {}
+  }
+
+  public sealed class Gp3Controller : GpController {
+    public override string CurrentDesignation { get; }
+    public override GpFunction CurrentFunction { get; }
+    public override int Index { get; }
+    public override string PinName { get; }
+
+    public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsI2cLedOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsI2cLedOutputAsync(CancellationToken cancellationToken = default) {}
+  }
+
+  public abstract class GpController : IGpioController {
+    public abstract string CurrentDesignation { get; }
+    public abstract GpFunction CurrentFunction { get; }
+    public PinMode CurrentMode { get; }
+    public abstract int Index { get; }
+    public bool IsUsedByGpioController { get; }
+    public PinValue LastUpdatedValue { get; }
+    public abstract string PinName { get; }
+
+    public void ConfigureAsGpio(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsGpioAsync(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    public PinMode GetMode(CancellationToken cancellationToken = default) {}
+    public async ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default) {}
+    public bool IsFunctionSupported(GpFunction function) {}
+    public PinValue Read(CancellationToken cancellationToken = default) {}
+    public async ValueTask<PinValue> ReadAsync(CancellationToken cancellationToken = default) {}
+    public void SetMode(PinMode mode, CancellationToken cancellationToken = default) {}
+    public async ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default) {}
+    protected void ThrowIfInvalidConfiguration(GpFunction requiredFunction) {}
+    public void Write(PinValue @value, CancellationToken cancellationToken = default) {}
+    public async ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default) {}
   }
 }
 

--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.0.apilist.cs
@@ -2,22 +2,21 @@
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
 //   InformationalVersion: 1.0.0-preview2+9335bdfc1b937075a51ac35af5bd1768fa3a1654
-//   TargetFramework: .NETCoreApp,Version=v10.0
+//   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
-//   Metadata: IsTrimmable=True
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
 //   Metadata: RepositoryCommit=9335bdfc1b937075a51ac35af5bd1768fa3a1654
 //   Referenced assemblies:
+//     Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.IO.UsbHid.Abstractions, Version=1.0.0.0, Culture=neutral
-//     System.Collections, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-//     System.ComponentModel, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-//     System.Device.Gpio, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
-//     System.Linq, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-//     System.Memory, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
-//     System.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Device.Gpio, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
+//     System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 
 using System;
@@ -371,8 +370,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
     public static ValueTask<int> ReadAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
     public static int ReadByte(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
     public static async ValueTask<int> ReadByteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
-    public static (IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet) ScanBus(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
-    public static async ValueTask<(IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet)> ScanBusAsync(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+    public static (IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet) ScanBus(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+    public static async ValueTask<(IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet)> ScanBusAsync(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
     public static void Write(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
     public static ValueTask WriteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
     public static void WriteByte(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
@@ -398,8 +397,7 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
 
     public Mcp2221AI2cDevice CreateDevice(I2cAddress deviceAddress, bool shouldDisposeMcp2221A = false) {}
     public Mcp2221AI2cDevice CreateDevice(I2cAddress deviceAddress, int transmissionSpeedInKbps, bool shouldDisposeMcp2221A = false) {}
-    [PreserveBaseOverrides]
-    public virtual Mcp2221AI2cDevice CreateDevice(int deviceAddress) {}
+    public override I2cDevice CreateDevice(int deviceAddress) {}
     public int Read(I2cAddress address, int transmissionSpeedInKbps, Span<byte> buffer, CancellationToken cancellationToken = default) {}
     public async ValueTask<int> ReadAsync(I2cAddress address, int transmissionSpeedInKbps, Memory<byte> buffer, CancellationToken cancellationToken = default) {}
     public override void RemoveDevice(int deviceAddress) {}

--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.1.apilist.cs
@@ -1,17 +1,17 @@
-// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview1)
+// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview2)
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview1+077854654720e368ee674194833ee52d976ac129
+//   InformationalVersion: 1.0.0-preview2+9335bdfc1b937075a51ac35af5bd1768fa3a1654
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
-//   Metadata: RepositoryCommit=077854654720e368ee674194833ee52d976ac129
+//   Metadata: RepositoryCommit=9335bdfc1b937075a51ac35af5bd1768fa3a1654
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.IO.UsbHid.Abstractions, Version=1.0.0.0, Culture=neutral
-//     System.Device.Gpio, Version=1.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
+//     System.Device.Gpio, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 
@@ -22,6 +22,7 @@ using System.Device.I2c;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.Devices.Mcp2221A;
+using Smdn.Devices.Mcp2221A.Peripherals.Gpio;
 using Smdn.Devices.Mcp2221A.Peripherals.I2c;
 using Smdn.IO.UsbHid;
 
@@ -35,6 +36,34 @@ namespace Smdn.Devices.Mcp2221A {
     string SerialNumber { get; }
   }
 
+  public static class IGpControllerGroupExtensions {
+    extension(IGpControllerGroup gpPins) {
+      public void ConfigureAllAsGpio(PinMode? gp0Mode = null, PinValue? gp0InitialValue = null, PinMode? gp1Mode = null, PinValue? gp1InitialValue = null, PinMode? gp2Mode = null, PinValue? gp2InitialValue = null, PinMode? gp3Mode = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAllAsGpioAsync(PinMode? gp0Mode = null, PinValue? gp0InitialValue = null, PinMode? gp1Mode = null, PinValue? gp1InitialValue = null, PinMode? gp2Mode = null, PinValue? gp2InitialValue = null, PinMode? gp3Mode = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default) {}
+      public void ConfigureAllAsGpioInput(CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAllAsGpioInputAsync(CancellationToken cancellationToken = default) {}
+      public void ConfigureAllAsGpioOutput(PinValue? gp0InitialValue = null, PinValue? gp1InitialValue = null, PinValue? gp2InitialValue = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAllAsGpioOutputAsync(PinValue? gp0InitialValue = null, PinValue? gp1InitialValue = null, PinValue? gp2InitialValue = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default) {}
+      public void ConfigureAllGpFunctions(GpFunction? gp0Function = null, GpFunction? gp1Function = null, GpFunction? gp2Function = null, GpFunction? gp3Function = null, CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAllGpFunctionsAsync(GpFunction? gp0Function = null, GpFunction? gp1Function = null, GpFunction? gp2Function = null, GpFunction? gp3Function = null, CancellationToken cancellationToken = default) {}
+      public (PinValue Gp0Value, PinValue Gp1Value, PinValue Gp2Value, PinValue Gp3Value) Read(CancellationToken cancellationToken = default) {}
+      public void Read(Span<PinValuePair> pinValuePairs, CancellationToken cancellationToken = default) {}
+      public ValueTask ReadAsync(Memory<PinValuePair> pinValuePairs, CancellationToken cancellationToken = default) {}
+      public ValueTask<(PinValue Gp0Value, PinValue Gp1Value, PinValue Gp2Value, PinValue Gp3Value)> ReadAsync(CancellationToken cancellationToken = default) {}
+      public void Write(PinValue? gp0Value = null, PinValue? gp1Value = null, PinValue? gp2Value = null, PinValue? gp3Value = null, CancellationToken cancellationToken = default) {}
+      public void Write(ReadOnlySpan<PinValuePair> pinValuePairs, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(PinValue? gp0Value = null, PinValue? gp1Value = null, PinValue? gp2Value = null, PinValue? gp3Value = null, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(ReadOnlyMemory<PinValuePair> pinValuePairs, CancellationToken cancellationToken = default) {}
+    }
+  }
+
+  public static class IGpioControllerExtensions {
+    public static void ConfigureAsGpioInput(this IGpioController controller, CancellationToken cancellationToken = default) {}
+    public static ValueTask ConfigureAsGpioInputAsync(this IGpioController controller, CancellationToken cancellationToken = default) {}
+    public static void ConfigureAsGpioOutput(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    public static ValueTask ConfigureAsGpioOutputAsync(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+  }
+
   public static class IMcp2221AInfoExtensions {
     extension(IMcp2221AInfo info) {
       public bool IsMcp2221A { get; }
@@ -46,58 +75,6 @@ namespace Smdn.Devices.Mcp2221A {
     IDisposable,
     IMcp2221AInfo
   {
-    public sealed class GP0Functionality : GPFunctionality {
-      public void ConfigureAsLedUrx(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsLedUrxAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsSspnd(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsSspndAsync(CancellationToken cancellationToken = default) {}
-    }
-
-    public sealed class GP1Functionality : GPFunctionality {
-      public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsClockOutput(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsClockOutputAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsInterruptDetection(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsInterruptDetectionAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsLedUtx(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsLedUtxAsync(CancellationToken cancellationToken = default) {}
-    }
-
-    public sealed class GP2Functionality : GPFunctionality {
-      public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsDac(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsDacAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsUsbCfg(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsUsbCfgAsync(CancellationToken cancellationToken = default) {}
-    }
-
-    public sealed class GP3Functionality : GPFunctionality {
-      public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsDac(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsDacAsync(CancellationToken cancellationToken = default) {}
-      public void ConfigureAsLedI2c(CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsLedI2cAsync(CancellationToken cancellationToken = default) {}
-    }
-
-    public abstract class GPFunctionality {
-      public string? PinDesignation { get; }
-      public string PinName { get; }
-
-      public void ConfigureAsGpio(PinMode initialDirection = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-      public ValueTask ConfigureAsGpioAsync(PinMode initialDirection = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-      public PinMode GetDirection(CancellationToken cancellationToken = default) {}
-      public ValueTask<PinMode> GetDirectionAsync(CancellationToken cancellationToken = default) {}
-      public PinValue GetValue(CancellationToken cancellationToken = default) {}
-      public ValueTask<PinValue> GetValueAsync(CancellationToken cancellationToken = default) {}
-      public void SetDirection(PinMode newDirection, CancellationToken cancellationToken = default) {}
-      public ValueTask SetDirectionAsync(PinMode newDirection, CancellationToken cancellationToken = default) {}
-      public void SetValue(PinValue newValue, CancellationToken cancellationToken = default) {}
-      public ValueTask SetValueAsync(PinValue newValue, CancellationToken cancellationToken = default) {}
-    }
-
     public const int DefaultProductId = 221;
     public const int DefaultVendorId = 1240;
     public const string FirmwareRevisionMcp2221 = "1.1";
@@ -117,20 +94,15 @@ namespace Smdn.Devices.Mcp2221A {
     public static ValueTask<Mcp2221A> CreateAsync<TServiceKey>(IServiceProvider serviceProvider, TServiceKey serviceKey, CancellationToken cancellationToken = default) {}
     public static ValueTask<Mcp2221A> CreateAsync<TServiceKey>(IServiceProvider serviceProvider, TServiceKey serviceKey, Predicate<IUsbHidDevice>? usbHidDeviceFilter, Predicate<IMcp2221AInfo>? mcp2221AFilter, CancellationToken cancellationToken = default) {}
     public static ValueTask<Mcp2221A> CreateAsync<TServiceKey>(IUsbHidDevice usbHidDevice, IServiceProvider? serviceProvider, TServiceKey serviceKey, bool shouldDisposeUsbHidDevice = false, CancellationToken cancellationToken = default) {}
-    [Obsolete("Use Create with IUsbHidDevice instead.", true)]
-    public static Mcp2221A Open(Func<IUsbHidDevice?> createHidDevice, IServiceProvider? serviceProvider = null) {}
-    [Obsolete("Use CreateAsync with IUsbHidDevice instead.", true)]
-    public static async ValueTask<Mcp2221A> OpenAsync(Func<IUsbHidDevice?> createHidDevice, IServiceProvider? serviceProvider = null) {}
-    public static bool TryCalculateMcp2221AI2cSpeedDivider(int i2cBusSpeedInKbps, out byte i2cSpeedDivider) {}
-    public static bool TryCalculateMcp2221I2cSpeedDivider(int i2cBusSpeedInKbps, out byte i2cSpeedDivider) {}
 
     public string ChipFactorySerialNumber { get; }
     public string FirmwareRevision { get; }
-    public Mcp2221A.GP0Functionality GP0 { get; }
-    public Mcp2221A.GP1Functionality GP1 { get; }
-    public Mcp2221A.GP2Functionality GP2 { get; }
-    public Mcp2221A.GP3Functionality GP3 { get; }
-    public IReadOnlyList<Mcp2221A.GPFunctionality> GPs { get; }
+    public Gp0Controller GpPin0 { get; }
+    public Gp1Controller GpPin1 { get; }
+    public Gp2Controller GpPin2 { get; }
+    public Gp3Controller GpPin3 { get; }
+    public IGpControllerGroup GpPins { get; }
+    public GpioController GpioController { get; }
     public string HardwareRevision { get; }
     public IUsbHidDevice HidDevice { get; }
     public Mcp2221AI2cBus I2c { get; }
@@ -213,6 +185,137 @@ namespace Smdn.Devices.Mcp2221A {
     public byte ToByte() {}
     public int ToInt32() {}
     public override string ToString() {}
+  }
+
+  public readonly record struct PinModePair {
+    public PinModePair(int PinNumber, PinMode PinMode) {}
+
+    public PinMode PinMode { get; init; }
+    public int PinNumber { get; init; }
+
+    [CompilerGenerated]
+    public void Deconstruct(out int PinNumber, out PinMode PinMode) {}
+    [CompilerGenerated]
+    public override string ToString() {}
+  }
+}
+
+namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
+  public interface IGpControllerGroup : IReadOnlyList<GpController> {
+    Gp0Controller Gp0 { get; }
+    Gp1Controller Gp1 { get; }
+    Gp2Controller Gp2 { get; }
+    Gp3Controller Gp3 { get; }
+
+    void ApplyGpioStates(ReadOnlySpan<PinValuePair> pinValuePairs, ReadOnlySpan<PinModePair> pinModePairs, CancellationToken cancellationToken = default);
+    ValueTask ApplyGpioStatesAsync(ReadOnlyMemory<PinValuePair> pinValuePairs, ReadOnlyMemory<PinModePair> pinModePairs, CancellationToken cancellationToken = default);
+    void ConfigureAllGpSettings(GpFunction? gp0Function = null, PinMode? gp0Mode = null, PinValue? gp0InitialValue = null, GpFunction? gp1Function = null, PinMode? gp1Mode = null, PinValue? gp1InitialValue = null, GpFunction? gp2Function = null, PinMode? gp2Mode = null, PinValue? gp2InitialValue = null, GpFunction? gp3Function = null, PinMode? gp3Mode = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAllGpSettingsAsync(GpFunction? gp0Function = null, PinMode? gp0Mode = null, PinValue? gp0InitialValue = null, GpFunction? gp1Function = null, PinMode? gp1Mode = null, PinValue? gp1InitialValue = null, GpFunction? gp2Function = null, PinMode? gp2Mode = null, PinValue? gp2InitialValue = null, GpFunction? gp3Function = null, PinMode? gp3Mode = null, PinValue? gp3InitialValue = null, CancellationToken cancellationToken = default);
+    void FetchGpioStates(Span<PinValuePair> pinValuePairs, Span<PinModePair> pinModePairs, CancellationToken cancellationToken = default);
+    ValueTask FetchGpioStatesAsync(Memory<PinValuePair> pinValuePairs, Memory<PinModePair> pinModePairs, CancellationToken cancellationToken = default);
+  }
+
+  public interface IGpioController {
+    void ConfigureAsGpio(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsGpioAsync(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
+    PinMode GetMode(CancellationToken cancellationToken = default);
+    ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default);
+    PinValue Read(CancellationToken cancellationToken = default);
+    ValueTask<PinValue> ReadAsync(CancellationToken cancellationToken = default);
+    void SetMode(PinMode mode, CancellationToken cancellationToken = default);
+    ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default);
+    void Write(PinValue @value, CancellationToken cancellationToken = default);
+    ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default);
+  }
+
+  public enum GpFunction : int {
+    Adc = 1,
+    ClockOutput = 5,
+    Dac = 2,
+    ExternalInterrupt = 3,
+    Gpio = 0,
+    LedOutput = 4,
+    UsbConfigureStatus = 7,
+    UsbSuspendStatus = 6,
+  }
+
+  public sealed class Gp0Controller : GpController {
+    public override string CurrentDesignation { get; }
+    public override GpFunction CurrentFunction { get; }
+    public override int Index { get; }
+    public override string PinName { get; }
+
+    public void ConfigureAsUrxLedOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsUrxLedOutputAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsUsbSuspendStatus(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsUsbSuspendStatusAsync(CancellationToken cancellationToken = default) {}
+  }
+
+  public sealed class Gp1Controller : GpController {
+    public override string CurrentDesignation { get; }
+    public override GpFunction CurrentFunction { get; }
+    public override int Index { get; }
+    public override string PinName { get; }
+
+    public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsClockOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsClockOutputAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsExternalInterrupt(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsExternalInterruptAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsUtxLedOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsUtxLedOutputAsync(CancellationToken cancellationToken = default) {}
+  }
+
+  public sealed class Gp2Controller : GpController {
+    public override string CurrentDesignation { get; }
+    public override GpFunction CurrentFunction { get; }
+    public override int Index { get; }
+    public override string PinName { get; }
+
+    public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsUsbConfigureStatus(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsUsbConfigureStatusAsync(CancellationToken cancellationToken = default) {}
+  }
+
+  public sealed class Gp3Controller : GpController {
+    public override string CurrentDesignation { get; }
+    public override GpFunction CurrentFunction { get; }
+    public override int Index { get; }
+    public override string PinName { get; }
+
+    public void ConfigureAsAdc(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsI2cLedOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsI2cLedOutputAsync(CancellationToken cancellationToken = default) {}
+  }
+
+  public abstract class GpController : IGpioController {
+    public abstract string CurrentDesignation { get; }
+    public abstract GpFunction CurrentFunction { get; }
+    public PinMode CurrentMode { get; }
+    public abstract int Index { get; }
+    public bool IsUsedByGpioController { get; }
+    public PinValue LastUpdatedValue { get; }
+    public abstract string PinName { get; }
+
+    public void ConfigureAsGpio(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsGpioAsync(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    public PinMode GetMode(CancellationToken cancellationToken = default) {}
+    public async ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default) {}
+    public bool IsFunctionSupported(GpFunction function) {}
+    public PinValue Read(CancellationToken cancellationToken = default) {}
+    public async ValueTask<PinValue> ReadAsync(CancellationToken cancellationToken = default) {}
+    public void SetMode(PinMode mode, CancellationToken cancellationToken = default) {}
+    public async ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default) {}
+    protected void ThrowIfInvalidConfiguration(GpFunction requiredFunction) {}
+    public void Write(PinValue @value, CancellationToken cancellationToken = default) {}
+    public async ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default) {}
   }
 }
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #6](https://github.com/smdn/Smdn.Devices.Mcp2221A/actions/runs/23748049045).

# Release target
- package_target_tag: `new-release/main/Smdn.Devices.Mcp2221A-1.0.0-preview2`
- package_prevver_ref: `releases/Smdn.Devices.Mcp2221A-1.0.0-preview1`
- package_prevver_tag: `releases/Smdn.Devices.Mcp2221A-1.0.0-preview1`
- package_id: `Smdn.Devices.Mcp2221A`
- package_id_with_version: `Smdn.Devices.Mcp2221A-1.0.0-preview2`
- package_version: `1.0.0-preview2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Devices.Mcp2221A-1.0.0-preview2-1774878411`
- release_tag: `releases/Smdn.Devices.Mcp2221A-1.0.0-preview2`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/a8ce138e318eccb6ee67d1c8a0b6ac3b`](https://gist.github.com/smdn/a8ce138e318eccb6ee67d1c8a0b6ac3b)
- artifact_name_nupkg: `Smdn.Devices.Mcp2221A.1.0.0-preview2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Devices.Mcp2221A.latest.nuspec
+++ Smdn.Devices.Mcp2221A.1.0.0-preview2.nuspec
@@ -1,39 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Devices.Mcp2221A</id>
-    <version>1.0.0-preview1</version>
+    <version>1.0.0-preview2</version>
     <title>Smdn.Devices.Mcp2221A</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Devices.Mcp2221A.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://smdn.jp/electronics/libs/Smdn.Devices.MCP2221/</projectUrl>
     <description>`Smdn.Devices.Mcp2221A` is a .NET library for the **Microchip Technology MCP2221 and MCP2221A, a USB2.0 to I2C/UART Protocol Converter with GPIO**. This library provides APIs that enable .NET applications to access the functions of the MCP2221/MCP2221A via the USB HID interface.</description>
-    <releaseNotes>See the release notes for [Smdn.Devices.Mcp2221A version 1.0.0-preview1](https://github.com/smdn/Smdn.Devices.Mcp2221A/releases/tag/releases%2FSmdn.Devices.Mcp2221A-1.0.0-preview1) on GitHub Releases.</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>See the release notes for [Smdn.Devices.Mcp2221A version 1.0.0-preview2](https://github.com/smdn/Smdn.Devices.Mcp2221A/releases/tag/releases%2FSmdn.Devices.Mcp2221A-1.0.0-preview2) on GitHub Releases.</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp USB,USB-HID,MCP2221,MCP2221A,I2C,GPIO,System.Device.Gpio</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Devices.Mcp2221A" branch="main" commit="077854654720e368ee674194833ee52d976ac129" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Devices.Mcp2221A" commit="9335bdfc1b937075a51ac35af5bd1768fa3a1654" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0-preview4" exclude="Build,Analyzers" />
-        <dependency id="System.Device.Gpio" version="[1.4.0, 5.0.0)" exclude="Build,Analyzers" />
+        <dependency id="System.Device.Gpio" version="[4.1.0, 5.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net10.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0-preview4" exclude="Build,Analyzers" />
-        <dependency id="System.Device.Gpio" version="[1.4.0, 5.0.0)" exclude="Build,Analyzers" />
+        <dependency id="System.Device.Gpio" version="[4.1.0, 5.0.0)" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0-preview4" exclude="Build,Analyzers" />
+        <dependency id="System.Device.Gpio" version="[1.5.0, 4.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0-preview4" exclude="Build,Analyzers" />
-        <dependency id="System.Device.Gpio" version="[1.4.0, 4.0.0)" exclude="Build,Analyzers" />
+        <dependency id="System.Device.Gpio" version="[1.5.0, 4.0.0)" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net10.0/Smdn.Devices.Mcp2221A.dll" target="lib/net10.0/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net10.0/Smdn.Devices.Mcp2221A.xml" target="lib/net10.0/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net8.0/Smdn.Devices.Mcp2221A.dll" target="lib/net8.0/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net8.0/Smdn.Devices.Mcp2221A.xml" target="lib/net8.0/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.0/Smdn.Devices.Mcp2221A.dll" target="lib/netstandard2.0/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.0/Smdn.Devices.Mcp2221A.xml" target="lib/netstandard2.0/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.1/Smdn.Devices.Mcp2221A.dll" target="lib/netstandard2.1/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.1/Smdn.Devices.Mcp2221A.xml" target="lib/netstandard2.1/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/.nuget/packages/smdn.msbuild.projectassets.common/1.7.1/project/images/package-icon.png" target="Smdn.Devices.Mcp2221A.png" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

