### PR TITLE
Add ADC input implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [Smdn.Devices.Mcp2221A examples](examples/Smdn.Devices.Mcp2221A/).
   - [x] GPIO
     - [x] GPIO read/write value
     - [x] GPIO get/set direction
-  - [ ] ADC inputs
+  - [x] ADC inputs
   - [ ] DAC outputs
   - [ ] Clock output
   - [ ] Interrupt detection
@@ -53,6 +53,11 @@ See [Smdn.Devices.Mcp2221A examples](examples/Smdn.Devices.Mcp2221A/).
   - [ ] SRAM read/write
     - [x] GP settings
     - [ ] Chip settings
+      - [ ] Pin options
+      - [ ] Clock output
+      - [ ] DAC outputs
+      - [x] ADC inputs
+      - [ ] Interrupt detection
   - [ ] Flash read/write
     - [ ] GP Settings
     - [ ] Chip Settings

--- a/examples/Smdn.Devices.Mcp2221A/ADC_Read/Program.cs
+++ b/examples/Smdn.Devices.Mcp2221A/ADC_Read/Program.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Threading;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Smdn.Devices.Mcp2221A;
+using Smdn.IO.UsbHid.DependencyInjection;
+
+var services = new ServiceCollection();
+
+services.AddHidSharpUsbHid();
+
+using var serviceProvider = services.BuildServiceProvider();
+
+using var device = Mcp2221AController.Create(serviceProvider);
+
+// configure GP1-GP3 as ADC input
+device.GpPin1.ConfigureAsAdc();
+device.GpPin2.ConfigureAsAdc();
+device.GpPin3.ConfigureAsAdc(VoltageReferenceSource.Vdd);
+// By specifying the VoltageReferenceSource, you can select and set
+// the reference voltage for the ADC module. The reference voltage
+// can be set to one of the following: VDD, 4.096 V, 2.048 V, 1.024 V,
+// or off (0 V).
+// Note that the reference voltage applies to the entire MCP2221A
+// ADC module, not to individual ADC pins. Therefore, the following
+// settings apply to all GP1–GP3.
+
+// get the current reference voltage setting
+var voltageReferenceSource = device.CurrentAdcReferenceSource;
+
+// read GP1 ADC 10-bit raw analog value (0-1023)
+var gp1Val = device.GpPin1.ReadAnalogRaw();
+
+// The ReadAnalogRaw() method reads the values of all ADC pins
+// in a single call. The value read most recently can be referenced
+// using LastReadAnalogRawValue property.
+var gp2Val = device.GpPin2.LastReadAnalogRawValue;
+var gp3Val = device.GpPin3.LastReadAnalogRawValue;
+
+// read and display GP1-GP3 pin values every 20 ms
+Console.Clear();
+
+var initialCursorPosition = Console.GetCursorPosition();
+
+const string ColumnFormat = "|{0,-6}|{1,-6}|{2,-6}|";
+
+var pinNames = string.Format(
+  ColumnFormat,
+  device.GpPin1.PinName,
+  device.GpPin2.PinName,
+  device.GpPin3.PinName
+);
+
+while (true) {
+  // read GP1-GP3 values all at once
+  var (gp1, gp2, gp3) = device.GpPins.ReadAnalogRaw();
+
+  Console.SetCursorPosition(initialCursorPosition.Left, initialCursorPosition.Top);
+
+  Console.WriteLine(pinNames);
+  Console.WriteLine(
+    ColumnFormat,
+    gp1,
+    gp2,
+    gp3
+  );
+
+  Thread.Sleep(20);
+}

--- a/examples/Smdn.Devices.Mcp2221A/ADC_Read/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/ADC_Read/Program.csproj
@@ -1,0 +1,31 @@
+﻿<!--
+SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Smdn.Devices.Mcp2221A" Version="1.0.0-preview2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+
+    <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
+
+    <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
+    <!--
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    -->
+
+    <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
+    <!--
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    -->
+  </ItemGroup>
+
+</Project>

--- a/examples/Smdn.Devices.Mcp2221A/ADC_Read/README.md
+++ b/examples/Smdn.Devices.Mcp2221A/ADC_Read/README.md
@@ -1,0 +1,2 @@
+# `ADC_Read`
+This example shows how to read ADC input values from MCP2221/MCP2221A.

--- a/examples/Smdn.Devices.Mcp2221A/ADC_ReadVoltage/Program.cs
+++ b/examples/Smdn.Devices.Mcp2221A/ADC_ReadVoltage/Program.cs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Threading;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Smdn.Devices.Mcp2221A;
+using Smdn.IO.UsbHid.DependencyInjection;
+
+var services = new ServiceCollection();
+
+services.AddHidSharpUsbHid();
+
+using var serviceProvider = services.BuildServiceProvider();
+
+using var device = Mcp2221AController.Create(serviceProvider);
+
+// configure GP1-GP3 as ADC input
+device.GpPin1.ConfigureAsAdc();
+device.GpPin2.ConfigureAsAdc();
+device.GpPin3.ConfigureAsAdc(VoltageReferenceSource.Vrm2048);
+
+// read and display GP1-GP3 pin values every 20 ms
+Console.Clear();
+
+var initialCursorPosition = Console.GetCursorPosition();
+
+const string HeaderColumnFormat = "|{0,-7}|{1,-7}|{2,-7}|";
+const string ValueColumnFormat = "|{0,-6:N3}V|{1,-6:N3}V|{2,-6:N3}V|";
+
+var pinNames = string.Format(
+  HeaderColumnFormat,
+  device.GpPin1.PinName,
+  device.GpPin2.PinName,
+  device.GpPin3.PinName
+);
+
+while (true) {
+  // Reads GP1-GP3 voltages all at once.
+  // Note that the ReadAnalogVoltage() method can only be used when VRM is
+  // set as the reference voltage. Calling this method when VDD is set
+  // as the reference voltage will result in an InvalidOperationException
+  // being thrown.
+  var (gp1Voltage, gp2Voltage, gp3Voltage) = device.GpPins.ReadAnalogVoltage();
+
+  Console.SetCursorPosition(initialCursorPosition.Left, initialCursorPosition.Top);
+
+  Console.WriteLine($"ADC voltage reference: {device.CurrentAdcReferenceSource}");
+  Console.WriteLine(pinNames);
+  Console.WriteLine(
+    ValueColumnFormat,
+    gp1Voltage,
+    gp2Voltage,
+    gp3Voltage
+  );
+
+  Thread.Sleep(20);
+}

--- a/examples/Smdn.Devices.Mcp2221A/ADC_ReadVoltage/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/ADC_ReadVoltage/Program.csproj
@@ -1,0 +1,31 @@
+﻿<!--
+SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Smdn.Devices.Mcp2221A" Version="1.0.0-preview2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+
+    <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
+
+    <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
+    <!--
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    -->
+
+    <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
+    <!--
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    -->
+  </ItemGroup>
+
+</Project>

--- a/examples/Smdn.Devices.Mcp2221A/ADC_ReadVoltage/README.md
+++ b/examples/Smdn.Devices.Mcp2221A/ADC_ReadVoltage/README.md
@@ -1,0 +1,2 @@
+# `ADC_ReadVoltage`
+This example shows how to read ADC input voltage from MCP2221/MCP2221A.

--- a/examples/examples.slnx
+++ b/examples/examples.slnx
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
 SPDX-License-Identifier: MIT
 -->
@@ -6,6 +6,12 @@ SPDX-License-Identifier: MIT
   <Folder Name="/Smdn.Devices.Mcp2221A/">
     <Project Path="Smdn.Devices.Mcp2221A/i2cscanbus/i2cscanbus.csproj" />
     <Project Path="Smdn.Devices.Mcp2221A/logging/logging.csproj" />
+  </Folder>
+  <Folder Name="/Smdn.Devices.Mcp2221A/ADC_Read/">
+    <Project Path="Smdn.Devices.Mcp2221A/ADC_Read/Program.csproj" />
+  </Folder>
+  <Folder Name="/Smdn.Devices.Mcp2221A/ADC_ReadVoltage/">
+    <Project Path="Smdn.Devices.Mcp2221A/ADC_ReadVoltage/Program.csproj" />
   </Folder>
   <Folder Name="/Smdn.Devices.Mcp2221A/blink-csharp/">
     <Project Path="Smdn.Devices.Mcp2221A/blink-csharp/blink.csproj" />

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/AdcAllChannelSample.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/AdcAllChannelSample.cs
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio;
+
+/// <summary>
+/// Represents a set of raw 10-bit ADC samples for all channels
+/// (ADC1, ADC2, and ADC3) of the MCP2221/MCP2221A.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This structure holds the snapshot of all ADC inputs retrieved
+/// from the device at a single point in time.
+/// </para>
+/// <para>
+/// Note that if a specific GP pin is not configured as an ADC input,
+/// the value of the corresponding field is undefined.
+/// </para>
+/// </remarks>
+[CLSCompliant(false)]
+public readonly record struct AdcAllChannelSample {
+  /// <summary>
+  /// The number of quantization steps for a 10-bit ADC (2^10).
+  /// </summary>
+  /// <remarks>
+  /// In ADC conversion formulas, the denominator should be 2^n (1024) rather
+  /// than 2^n - 1 (1023). This is because each digital value represents a
+  /// voltage range (quantization bucket) of width Vref / 2^n, and the
+  /// full-scale range is divided into 2^n equal intervals.
+  /// </remarks>
+  private const double AdcResolution = 1024.0;
+
+  /// <summary>
+  /// Gets the 10-bit raw analog value from ADC1 (GP1).
+  /// </summary>
+  public ushort Adc1 { get; init; }
+
+  /// <summary>
+  /// Gets the 10-bit raw analog value from ADC2 (GP2).
+  /// </summary>
+  public ushort Adc2 { get; init; }
+
+  /// <summary>
+  /// Gets the 10-bit raw analog value from ADC3 (GP3).
+  /// </summary>
+  public ushort Adc3 { get; init; }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="AdcAllChannelSample"/> struct
+  /// with ADC raw values for all channels.
+  /// </summary>
+  /// <param name="adc1">10-bit raw analog value from ADC1 (GP1).</param>
+  /// <param name="adc2">10-bit raw analog value from ADC2 (GP2).</param>
+  /// <param name="adc3">10-bit raw analog value from ADC3 (GP3).</param>
+  /// <exception cref="ArgumentOutOfRangeException">
+  /// <paramref name="adc1"/>, <paramref name="adc2"/>, or <paramref name="adc3"/>
+  /// is greater than 1023 (the maximum value for a 10-bit ADC).
+  /// </exception>
+  public AdcAllChannelSample(ushort adc1, ushort adc2, ushort adc3)
+  {
+    if (1024 <= adc1)
+      throw new ArgumentOutOfRangeException(message: "Value must be 10-bit (0-1023).", paramName: nameof(adc1), actualValue: adc1);
+    if (1024 <= adc2)
+      throw new ArgumentOutOfRangeException(message: "Value must be 10-bit (0-1023).", paramName: nameof(adc2), actualValue: adc2);
+    if (1024 <= adc3)
+      throw new ArgumentOutOfRangeException(message: "Value must be 10-bit (0-1023).", paramName: nameof(adc3), actualValue: adc3);
+
+    Adc1 = adc1;
+    Adc2 = adc2;
+    Adc3 = adc3;
+  }
+
+  /// <summary>
+  /// Returns the raw analog values for all channels converted to <see cref="int"/>.
+  /// </summary>
+  /// <returns>
+  /// A tuple containing the 10-bit raw analog values as <see cref="int"/>
+  /// for (ADC1, ADC2, ADC3).
+  /// </returns>
+  /// <remarks>
+  /// This method is provided for convenience when performing arithmetic operations
+  /// or interfacing with APIs that require <see cref="int"/> instead of <see cref="ushort"/>.
+  /// </remarks>
+  public (int Adc1, int Adc2, int Adc3) AsInt32()
+    => (Adc1, Adc2, Adc3);
+
+  /// <summary>
+  /// Converts the raw analog values of all channels to voltage values [V]
+  /// based on the specified reference source.
+  /// </summary>
+  /// <param name="adcVoltageReference">
+  /// The <see cref="VoltageReferenceSource"/> currently configured for the ADC module.
+  /// </param>
+  /// <returns>
+  /// A tuple containing the converted voltage values [V] for (Adc1, Adc2, Adc3).
+  /// </returns>
+  /// <remarks>
+  /// <para>
+  /// If <paramref name="adcVoltageReference"/> is <see cref="VoltageReferenceSource.VrmOff"/>,
+  /// this method always returns 0.0 for all channels regardless of the raw values.
+  /// </para>
+  /// <para>
+  /// Note that this method does not account for cases where the actual VDD supplied
+  /// to the MCP2221A is lower than the reference voltage specified by <paramref name="adcVoltageReference"/>.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="InvalidOperationException">
+  /// Thrown when <paramref name="adcVoltageReference"/> is <see cref="VoltageReferenceSource.Vdd"/>,
+  /// as the Vdd voltage value is required for calculation but not provided here.
+  /// </exception>
+  /// <exception cref="ArgumentException">
+  /// Thrown when <paramref name="adcVoltageReference"/> is an undefined or unsupported
+  /// <see cref="VoltageReferenceSource"/> value.
+  /// </exception>
+  public
+  (double Adc1, double Adc2, double Adc3)
+  AsVoltage(VoltageReferenceSource adcVoltageReference)
+    => adcVoltageReference switch {
+      VoltageReferenceSource.VrmOff => default, // (0.0, 0.0, 0.0)
+      VoltageReferenceSource.Vrm1024 => AsVoltage(referenceVoltage: 1.024),
+      VoltageReferenceSource.Vrm2048 => AsVoltage(referenceVoltage: 2.048),
+      VoltageReferenceSource.Vrm4096 => AsVoltage(referenceVoltage: 4.096),
+
+      VoltageReferenceSource.Vdd
+        => throw new InvalidOperationException(
+          $"{nameof(VoltageReferenceSource)}.{nameof(VoltageReferenceSource.Vdd)} is not supported in this method. Use a method that accepts a specific Vdd voltage value instead."
+        ),
+
+      var invalid
+        => throw new ArgumentException(
+          message: $"Undefined {nameof(VoltageReferenceSource)} value: {invalid}",
+          paramName: nameof(adcVoltageReference)
+        ),
+    };
+
+  /// <summary>
+  /// Converts the raw analog values to voltage values [V]
+  /// based on the specified reference voltage value.
+  /// </summary>
+  /// <param name="referenceVoltage">
+  /// The reference voltage [V] used for ADC conversion (e.g., VDD or VRM voltage).
+  /// </param>
+  /// <returns>
+  /// A tuple containing the converted voltage values [V] for (Adc1, Adc2, Adc3).
+  /// </returns>
+  /// <exception cref="ArgumentOutOfRangeException">
+  /// Thrown when <paramref name="referenceVoltage"/> is negative.
+  /// </exception>
+  /// <exception cref="ArgumentException">
+  /// Thrown when <paramref name="referenceVoltage"/> is NaN or Infinity.
+  /// </exception>
+  public
+  (double Adc1, double Adc2, double Adc3)
+  AsVoltage(double referenceVoltage)
+  {
+    if (double.IsNaN(referenceVoltage) || double.IsInfinity(referenceVoltage))
+      throw new ArgumentException(message: "Reference voltage must be a finite number.", paramName: nameof(referenceVoltage));
+
+    if (referenceVoltage < 0.0)
+      throw new ArgumentOutOfRangeException(message: "Reference voltage cannot be negative.", paramName: nameof(referenceVoltage));
+
+    if (referenceVoltage == 0.0)
+      return default; // (0.0, 0.0, 0.0)
+
+    // Calculation: (Reference voltage [V] * RawValue) / Resolution
+    return (
+      referenceVoltage * Adc1 / AdcResolution,
+      referenceVoltage * Adc2 / AdcResolution,
+      referenceVoltage * Adc3 / AdcResolution
+    );
+  }
+}

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Gp1Controller.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Gp1Controller.cs
@@ -46,6 +46,14 @@ public sealed class Gp1Controller :
     _ => throw new NotSupportedException(),
   };
 
+  /// <inheritdoc/>
+  VoltageReferenceSource IAdcController.CurrentAdcReferenceSource
+    => GpioDriver.CurrentAdcReferenceSource;
+
+  /// <inheritdoc/>
+  public int LastReadAnalogRawValue
+    => GpioDriver.GetLastFetchedAdcRawValue(Index);
+
   internal Gp1Controller(Mcp2221AGpioDriver gpioDriver)
     : base(gpioDriver)
   {
@@ -96,18 +104,58 @@ public sealed class Gp1Controller :
     );
 
   /// <inheritdoc/>
-  public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default)
+  public ValueTask ConfigureAsAdcAsync(
+    VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd,
+    CancellationToken cancellationToken = default
+  )
     => ConfigureGpDesignationAsync(
       gpDesignation: GpDesignation.AlternateFunction0,
+      dacVoltageReferenceSource: null,
+      dacOutputValue: null,
+      adcVoltageReferenceSource: voltageReferenceSource,
       cancellationToken: cancellationToken
     );
 
   /// <inheritdoc/>
-  public void ConfigureAsAdc(CancellationToken cancellationToken = default)
+  public void ConfigureAsAdc(
+    VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd,
+    CancellationToken cancellationToken = default
+  )
     => ConfigureGpDesignation(
       gpDesignation: GpDesignation.AlternateFunction0,
+      dacVoltageReferenceSource: null,
+      dacOutputValue: null,
+      adcVoltageReferenceSource: voltageReferenceSource,
       cancellationToken: cancellationToken
     );
+
+  /// <inheritdoc/>
+  public int ReadAnalogRaw(
+    CancellationToken cancellationToken = default
+  )
+  {
+    GpioDriver.Transceiver.ThrowIfDisposed();
+
+    ThrowIfInvalidConfiguration(GpFunction.Adc);
+
+    GpioDriver.FetchAdcRawValues(cancellationToken);
+
+    return GpioDriver.GetLastFetchedAdcRawValue(Index);
+  }
+
+  /// <inheritdoc/>
+  public async ValueTask<int> ReadAnalogRawAsync(
+    CancellationToken cancellationToken = default
+  )
+  {
+    GpioDriver.Transceiver.ThrowIfDisposed();
+
+    ThrowIfInvalidConfiguration(GpFunction.Adc);
+
+    await GpioDriver.FetchAdcRawValuesAsync(cancellationToken).ConfigureAwait(false);
+
+    return GpioDriver.GetLastFetchedAdcRawValue(Index);
+  }
 
   /// <inheritdoc/>
   public ValueTask ConfigureAsClockOutputAsync(CancellationToken cancellationToken = default)

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Gp2Controller.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Gp2Controller.cs
@@ -42,6 +42,14 @@ public sealed class Gp2Controller :
     _ => throw new NotSupportedException(),
   };
 
+  /// <inheritdoc/>
+  VoltageReferenceSource IAdcController.CurrentAdcReferenceSource
+    => GpioDriver.CurrentAdcReferenceSource;
+
+  /// <inheritdoc/>
+  public int LastReadAnalogRawValue
+    => GpioDriver.GetLastFetchedAdcRawValue(Index);
+
   internal Gp2Controller(Mcp2221AGpioDriver gpioDriver)
     : base(gpioDriver)
   {
@@ -71,18 +79,58 @@ public sealed class Gp2Controller :
     );
 
   /// <inheritdoc/>
-  public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default)
+  public ValueTask ConfigureAsAdcAsync(
+    VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd,
+    CancellationToken cancellationToken = default
+  )
     => ConfigureGpDesignationAsync(
       gpDesignation: GpDesignation.AlternateFunction0,
+      dacVoltageReferenceSource: null,
+      dacOutputValue: null,
+      adcVoltageReferenceSource: voltageReferenceSource,
       cancellationToken: cancellationToken
     );
 
   /// <inheritdoc/>
-  public void ConfigureAsAdc(CancellationToken cancellationToken = default)
+  public void ConfigureAsAdc(
+    VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd,
+    CancellationToken cancellationToken = default
+  )
     => ConfigureGpDesignation(
       gpDesignation: GpDesignation.AlternateFunction0,
+      dacVoltageReferenceSource: null,
+      dacOutputValue: null,
+      adcVoltageReferenceSource: voltageReferenceSource,
       cancellationToken: cancellationToken
     );
+
+  /// <inheritdoc/>
+  public int ReadAnalogRaw(
+    CancellationToken cancellationToken = default
+  )
+  {
+    GpioDriver.Transceiver.ThrowIfDisposed();
+
+    ThrowIfInvalidConfiguration(GpFunction.Adc);
+
+    GpioDriver.FetchAdcRawValues(cancellationToken);
+
+    return GpioDriver.GetLastFetchedAdcRawValue(Index);
+  }
+
+  /// <inheritdoc/>
+  public async ValueTask<int> ReadAnalogRawAsync(
+    CancellationToken cancellationToken = default
+  )
+  {
+    GpioDriver.Transceiver.ThrowIfDisposed();
+
+    ThrowIfInvalidConfiguration(GpFunction.Adc);
+
+    await GpioDriver.FetchAdcRawValuesAsync(cancellationToken).ConfigureAwait(false);
+
+    return GpioDriver.GetLastFetchedAdcRawValue(Index);
+  }
 
   /// <exception cref="InvalidOperationException">
   /// Thrown when <see cref="GpController.IsUsedByGpioController"/> is <see langword="true"/>.

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Gp3Controller.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Gp3Controller.cs
@@ -42,6 +42,14 @@ public sealed class Gp3Controller :
     _ => throw new NotSupportedException(),
   };
 
+  /// <inheritdoc/>
+  VoltageReferenceSource IAdcController.CurrentAdcReferenceSource
+    => GpioDriver.CurrentAdcReferenceSource;
+
+  /// <inheritdoc/>
+  public int LastReadAnalogRawValue
+    => GpioDriver.GetLastFetchedAdcRawValue(Index);
+
   internal Gp3Controller(Mcp2221AGpioDriver gpioDriver)
     : base(gpioDriver)
   {
@@ -71,18 +79,58 @@ public sealed class Gp3Controller :
     );
 
   /// <inheritdoc/>
-  public ValueTask ConfigureAsAdcAsync(CancellationToken cancellationToken = default)
+  public ValueTask ConfigureAsAdcAsync(
+    VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd,
+    CancellationToken cancellationToken = default
+  )
     => ConfigureGpDesignationAsync(
       gpDesignation: GpDesignation.AlternateFunction0,
+      dacVoltageReferenceSource: null,
+      dacOutputValue: null,
+      adcVoltageReferenceSource: voltageReferenceSource,
       cancellationToken: cancellationToken
     );
 
   /// <inheritdoc/>
-  public void ConfigureAsAdc(CancellationToken cancellationToken = default)
+  public void ConfigureAsAdc(
+    VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd,
+    CancellationToken cancellationToken = default
+  )
     => ConfigureGpDesignation(
       gpDesignation: GpDesignation.AlternateFunction0,
+      dacVoltageReferenceSource: null,
+      dacOutputValue: null,
+      adcVoltageReferenceSource: voltageReferenceSource,
       cancellationToken: cancellationToken
     );
+
+  /// <inheritdoc/>
+  public int ReadAnalogRaw(
+    CancellationToken cancellationToken = default
+  )
+  {
+    GpioDriver.Transceiver.ThrowIfDisposed();
+
+    ThrowIfInvalidConfiguration(GpFunction.Adc);
+
+    GpioDriver.FetchAdcRawValues(cancellationToken);
+
+    return GpioDriver.GetLastFetchedAdcRawValue(Index);
+  }
+
+  /// <inheritdoc/>
+  public async ValueTask<int> ReadAnalogRawAsync(
+    CancellationToken cancellationToken = default
+  )
+  {
+    GpioDriver.Transceiver.ThrowIfDisposed();
+
+    ThrowIfInvalidConfiguration(GpFunction.Adc);
+
+    await GpioDriver.FetchAdcRawValuesAsync(cancellationToken).ConfigureAwait(false);
+
+    return GpioDriver.GetLastFetchedAdcRawValue(Index);
+  }
 
   /// <exception cref="InvalidOperationException">
   /// Thrown when <see cref="GpController.IsUsedByGpioController"/> is <see langword="true"/>.

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.cs
@@ -265,4 +265,36 @@ public abstract partial class GpController {
       gpioValue: gpioInitialValue,
       cancellationToken: cancellationToken
     );
+
+  private protected ValueTask ConfigureGpDesignationAsync(
+    GpDesignation gpDesignation,
+    VoltageReferenceSource? dacVoltageReferenceSource,
+    int? dacOutputValue,
+    VoltageReferenceSource? adcVoltageReferenceSource,
+    CancellationToken cancellationToken
+  )
+    => GpioDriver.ConfigureGpDesignationAsync(
+      gp: Index,
+      gpDesignation: gpDesignation,
+      dacVoltageReferenceSource: dacVoltageReferenceSource,
+      dacOutputValue: dacOutputValue,
+      adcVoltageReferenceSource: adcVoltageReferenceSource,
+      cancellationToken: cancellationToken
+    );
+
+  private protected void ConfigureGpDesignation(
+    GpDesignation gpDesignation,
+    VoltageReferenceSource? dacVoltageReferenceSource,
+    int? dacOutputValue,
+    VoltageReferenceSource? adcVoltageReferenceSource,
+    CancellationToken cancellationToken
+  )
+    => GpioDriver.ConfigureGpDesignation(
+      gp: Index,
+      gpDesignation: gpDesignation,
+      dacVoltageReferenceSource: dacVoltageReferenceSource,
+      dacOutputValue: dacOutputValue,
+      adcVoltageReferenceSource: adcVoltageReferenceSource,
+      cancellationToken: cancellationToken
+    );
 }

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/IAdcController.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/IAdcController.cs
@@ -6,19 +6,42 @@ using System.Threading.Tasks;
 
 namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio;
 
-internal interface IAdcController {
-  /// <param name="cancellationToken">
-  /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
-  /// The default value is <see cref="CancellationToken.None"/>.
-  /// </param>
-  /// <exception cref="InvalidOperationException">
-  /// Thrown when <see cref="GpController.IsUsedByGpioController"/> is <see langword="true"/>.
-  /// </exception>
-  /// <seealso cref="GpFunction.Adc"/>
-  ValueTask ConfigureAsAdcAsync(
-    CancellationToken cancellationToken = default
-  );
+/// <summary>
+/// Defines an interface for controlling the Analog-to-Digital
+/// Converter (ADC) pins of the MCP2221/MCP2221A.
+/// </summary>
+public interface IAdcController {
+  /// <summary>
+  /// Gets the current voltage reference source configured for the ADC module.
+  /// </summary>
+  /// <remarks>
+  /// This property represents the global configuration for the ADC module
+  /// of the MCP2221A. Changing the reference source on one GP pin will
+  /// affect all other GP pins configured as ADC inputs.
+  /// </remarks>
+  VoltageReferenceSource CurrentAdcReferenceSource { get; }
 
+  /// <summary>
+  /// Gets the 10-bit raw analog value (0-1023) retrieved during the
+  /// last read operation.
+  /// </summary>
+  /// <remarks>
+  /// This property returns the cached value from the last call to
+  /// <see cref="ReadAnalogRaw(CancellationToken)"/> or <see cref="ReadAnalogRawAsync(CancellationToken)"/>.
+  /// If no read operation has been performed yet, this property returns 0.
+  /// </remarks>
+  /// <seealso cref="GpFunction.Adc"/>
+  /// <seealso cref="ReadAnalogRaw(CancellationToken)"/>
+  /// <seealso cref="ReadAnalogRawAsync(CancellationToken)"/>
+  int LastReadAnalogRawValue { get; }
+
+  /// <summary>
+  /// Configures the GP pin to function as an Analog-to-Digital Converter (ADC) input
+  /// and sets the voltage reference source for the analog module.
+  /// </summary>
+  /// <param name="voltageReferenceSource">
+  /// The <see cref="VoltageReferenceSource"/> to be used for the ADC.
+  /// </param>
   /// <param name="cancellationToken">
   /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
   /// The default value is <see cref="CancellationToken.None"/>.
@@ -26,12 +49,52 @@ internal interface IAdcController {
   /// <exception cref="InvalidOperationException">
   /// Thrown when <see cref="GpController.IsUsedByGpioController"/> is <see langword="true"/>.
   /// </exception>
+  /// <remarks>
+  /// Note that the <paramref name="voltageReferenceSource"/> is a global setting
+  /// for the entire analog module. Updating this value through one GP pin will
+  /// simultaneously change the reference source for all other ADC-enabled pins.
+  /// </remarks>
+  /// <seealso cref="CurrentAdcReferenceSource"/>
   /// <seealso cref="GpFunction.Adc"/>
   void ConfigureAsAdc(
+    VoltageReferenceSource voltageReferenceSource,
     CancellationToken cancellationToken = default
   );
 
-#if __FUTURE_VERSION
-  int AdcValue { get; }
-#endif
+  /// <summary>
+  /// Asynchronously configures the GP pin to function as an Analog-to-Digital
+  /// Converter (ADC) input and sets the voltage reference source for the analog module.
+  /// </summary>
+  /// <inheritdoc cref="ConfigureAsAdc(VoltageReferenceSource, CancellationToken)"/>
+  /// <returns>
+  /// A <see cref="ValueTask"/> representing the asynchronous operation.
+  /// </returns>
+  ValueTask ConfigureAsAdcAsync(
+    VoltageReferenceSource voltageReferenceSource,
+    CancellationToken cancellationToken = default
+  );
+
+  /// <summary>
+  /// Reads the current 10-bit raw analog value (0-1023) from the GP pin.
+  /// </summary>
+  /// <param name="cancellationToken">
+  /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
+  /// The default value is <see cref="CancellationToken.None"/>.
+  /// </param>
+  /// <returns>The 10-bit raw analog value (0-1023).</returns>
+  int ReadAnalogRaw(
+    CancellationToken cancellationToken = default
+  );
+
+  /// <inheritdoc cref="ReadAnalogRaw(CancellationToken)"/>
+  /// <summary>
+  /// Asynchronously reads the current 10-bit raw analog value (0-1023) from the GP pin.
+  /// </summary>
+  /// <returns>
+  /// A <see cref="ValueTask"/> representing the asynchronous operation,
+  /// containing the 10-bit raw analog value (0-1023).
+  /// </returns>
+  ValueTask<int> ReadAnalogRawAsync(
+    CancellationToken cancellationToken = default
+  );
 }

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/IGpControllerGroup.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/IGpControllerGroup.cs
@@ -63,6 +63,16 @@ public interface IGpControllerGroup : IReadOnlyList<GpController> {
   Gp3Controller Gp3 { get; }
 
   /// <summary>
+  /// Gets the current voltage reference source configured for the ADC module.
+  /// </summary>
+  /// <remarks>
+  /// This property represents the global configuration for the ADC module
+  /// of the MCP2221A. Changing the reference source on one GP pin will
+  /// affect all other GP pins configured as ADC inputs.
+  /// </remarks>
+  VoltageReferenceSource CurrentAdcReferenceSource { get; }
+
+  /// <summary>
   /// Configures all settings for GP pins (GP0-GP3), including functions, modes,
   /// and initial values, in a single communication.
   /// </summary>
@@ -330,6 +340,39 @@ public interface IGpControllerGroup : IReadOnlyList<GpController> {
   ValueTask ApplyGpioStatesAsync(
     ReadOnlyMemory<PinValuePair> pinValuePairs,
     ReadOnlyMemory<PinModePair> pinModePairs,
+    CancellationToken cancellationToken = default
+  );
+
+  /// <summary>
+  /// Fetches the current 10-bit raw input values from all ADC channels
+  /// (ADC1, ADC2, and ADC3) by sending a command to the device and updates
+  /// the internal cache.
+  /// </summary>
+  /// <param name="cancellationToken">
+  /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
+  /// The default value is <see cref="CancellationToken.None"/>.
+  /// </param>
+  /// <returns>
+  /// An <see cref="AdcAllChannelSample"/> containing the fetched 10-bit raw values.
+  /// </returns>
+  /// <exception cref="OperationCanceledException">
+  /// The operation was canceled.
+  /// </exception>
+  AdcAllChannelSample FetchAdcRawValues(
+    CancellationToken cancellationToken = default
+  );
+
+  /// <summary>
+  /// Asynchronously fetches the current 10-bit raw input values from all ADC channels
+  /// (ADC1, ADC2, and ADC3) by sending a command to the device and updates
+  /// the internal cache.
+  /// </summary>
+  /// <inheritdoc cref="FetchAdcRawValues(CancellationToken)"/>
+  /// <returns>
+  /// A <see cref="ValueTask{AdcAllChannelSample}"/> representing the asynchronous
+  /// operation, containing the fetched 10-bit raw values.
+  /// </returns>
+  ValueTask<AdcAllChannelSample> FetchAdcRawValuesAsync(
     CancellationToken cancellationToken = default
   );
 }

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.Analog.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.Analog.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 smdn <smdn@smdn.jp>
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
 using System;
 using System.Buffers.Binary;

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.Analog.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.Analog.cs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2021 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Buffers.Binary;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio;
+
+#pragma warning disable IDE0040
+partial class Mcp2221AGpioDriver {
+#pragma warning restore IDE0040
+  private AdcAllChannelSample lastFetchedAdcSample;
+
+  private static class GetAdcChannelValuesCommand {
+#pragma warning disable IDE0060, SA1313
+    public static void ConstructCommand(
+      Span<byte> comm,
+      ReadOnlySpan<byte> userData,
+      None _
+    )
+#pragma warning restore IDE0060, SA1313
+    {
+      // [MCP2221A] 3.1.1 STATUS/SET PARAMETERS
+      comm[0] = 0x10; // [0] Status/Set Parameters
+    }
+
+#pragma warning disable IDE0060, SA1313
+    public static AdcAllChannelSample ParseResponse(
+      ReadOnlySpan<byte> resp,
+      None _
+    )
+#pragma warning restore IDE0060, SA1313
+    {
+      // [MCP2221A] 3.1.1 STATUS/SET PARAMETERS
+      if (resp[1] != 0x00) // Command completed successfully
+        throw new Mcp2221ACommandException($"unexpected command response ({resp[1]:X2})");
+
+      // [50-55] ADC Data (16-bit) values; 3x(16-bit) little-endian ADC channel values
+      return new(
+        adc1: BinaryPrimitives.ReadUInt16LittleEndian(resp.Slice(50, 2)),
+        adc2: BinaryPrimitives.ReadUInt16LittleEndian(resp.Slice(52, 2)),
+        adc3: BinaryPrimitives.ReadUInt16LittleEndian(resp.Slice(54, 2))
+      );
+    }
+  }
+
+  /// <inheritdoc/>
+  public VoltageReferenceSource CurrentAdcReferenceSource
+    => (VoltageReferenceSource)(sramSettings.ReadAdcSettingsByte() & 0b_0_0000_11_1);
+
+  /// <summary>
+  /// Returns the cached 10-bit raw ADC input value (0-1023) for the specified GP pin
+  /// retrieved during the last call to <see cref="FetchAdcRawValues"/> or
+  /// <see cref="FetchAdcRawValuesAsync"/>.
+  /// </summary>
+  /// <param name="gp">
+  /// The GP pin number (typically 1, 2, or 3) whose cached ADC value is to be retrieved.
+  /// </param>
+  /// <returns>The 10-bit raw ADC value (0-1023).</returns>
+  /// <remarks>
+  /// <param>
+  /// This method does not communicate with the device; it returns the value from the
+  /// local cache.
+  /// </param>
+  /// <param>
+  /// If <see cref="FetchAdcRawValues"/> or <see cref="FetchAdcRawValuesAsync"/> has not
+  /// been called yet, this method always returns 0.
+  /// </param>
+  /// </remarks>
+  public int GetLastFetchedAdcRawValue(int gp)
+    => gp switch {
+      1 => lastFetchedAdcSample.Adc1,
+      2 => lastFetchedAdcSample.Adc2,
+      3 => lastFetchedAdcSample.Adc3,
+      _ => throw new ArgumentOutOfRangeException(
+        paramName: nameof(gp),
+        actualValue: gp,
+        message: $"The GP pin index {gp} is out of range for the Analog-to-Digital Converter (ADC) channels."
+      ),
+    };
+
+  /// <inheritdoc/>
+  public AdcAllChannelSample FetchAdcRawValues(
+    CancellationToken cancellationToken
+  )
+  {
+    return lastFetchedAdcSample = Transceiver.Command(
+      cancellationToken: cancellationToken,
+      constructCommand: GetAdcChannelValuesCommand.ConstructCommand,
+      parseResponse: GetAdcChannelValuesCommand.ParseResponse
+    );
+  }
+
+  /// <inheritdoc/>
+  public async ValueTask<AdcAllChannelSample> FetchAdcRawValuesAsync(
+    CancellationToken cancellationToken
+  )
+  {
+    return lastFetchedAdcSample = await Transceiver.CommandAsync(
+      cancellationToken: cancellationToken,
+      constructCommand: GetAdcChannelValuesCommand.ConstructCommand,
+      parseResponse: GetAdcChannelValuesCommand.ParseResponse
+    ).ConfigureAwait(false);
+  }
+}

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.GpSettings.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.GpSettings.cs
@@ -38,6 +38,20 @@ partial class Mcp2221AGpioDriver {
 
       // TODO: update other SRAM settings
 
+      // [6] Bit 7-6: DAC Reference voltage option
+      // [6] Bit 5: DAC reference option
+      // [6] Bit 4-0: Power-up DAC value
+      sramSettings.ModifyDacSettings(
+        dacVoltageReferenceSource: ParseVoltageSelectionAndReferenceVoltageBits((resp[6] & 0b_11_1_00000) >> 5),
+        dacOutputValue: resp[6] & 0b_00_0_11111
+      );
+
+      // [7] Bit 4-3: ADC Reference Voltage
+      // [7] Bit 2: ADC Reference Option
+      sramSettings.ModifyAdcSettings(
+        adcVoltageReferenceSource: ParseVoltageSelectionAndReferenceVoltageBits((resp[7] & 0b_0_0_0_11_1_0_0) >> 2)
+      );
+
       sramSettings.StoreGpSettingsBytes(
         gpSettingBytes: resp.Slice(22, SramSettings.SizeOfGpSettings) // [22-25] GP0-3 Settings
       );
@@ -47,6 +61,21 @@ partial class Mcp2221AGpioDriver {
 
       return default;
     }
+
+    private static VoltageReferenceSource ParseVoltageSelectionAndReferenceVoltageBits(
+      int voltageSelectionAndReferenceVoltageBits
+    )
+      => voltageSelectionAndReferenceVoltageBits switch {
+        0b_00_0 => VoltageReferenceSource.Vdd,
+
+        var vrm when (vrm & 0b_11_0) is
+          0b_11_0 or
+          0b_10_0 or
+          0b_01_0 or
+          0b_00_0 => (VoltageReferenceSource)(vrm | 0b_00_1),
+
+        _ => default, // unknown
+      };
   }
 
   private static class SetSramSettingsCommand {
@@ -170,6 +199,78 @@ partial class Mcp2221AGpioDriver {
           direction: gpioDirection,
           outputValue: gpioValue
         ),
+        cancellationToken: cancellationToken
+      );
+    }
+    catch {
+      sramSettings.Restore();
+      throw;
+    }
+  }
+
+  internal async ValueTask ConfigureGpDesignationAsync(
+    int gp,
+    GpDesignation gpDesignation,
+    VoltageReferenceSource? dacVoltageReferenceSource,
+    int? dacOutputValue,
+    VoltageReferenceSource? adcVoltageReferenceSource,
+    CancellationToken cancellationToken
+  )
+  {
+    ThrowIfUsedByGpioController(gp);
+
+    try {
+      await SetGpSettingsAsync(
+        sramSettings: sramSettings
+          .ModifyGpSettings(
+            gp: gp,
+            designation: gpDesignation,
+            direction: null,
+            outputValue: null
+          )
+          .ModifyDacSettings(
+            dacVoltageReferenceSource: dacVoltageReferenceSource,
+            dacOutputValue: dacOutputValue
+          )
+          .ModifyAdcSettings(
+            adcVoltageReferenceSource: adcVoltageReferenceSource
+          ),
+        cancellationToken: cancellationToken
+      ).ConfigureAwait(false);
+    }
+    catch {
+      sramSettings.Restore();
+      throw;
+    }
+  }
+
+  internal void ConfigureGpDesignation(
+    int gp,
+    GpDesignation gpDesignation,
+    VoltageReferenceSource? dacVoltageReferenceSource,
+    int? dacOutputValue,
+    VoltageReferenceSource? adcVoltageReferenceSource,
+    CancellationToken cancellationToken
+  )
+  {
+    ThrowIfUsedByGpioController(gp);
+
+    try {
+      SetGpSettings(
+        sramSettings: sramSettings
+          .ModifyGpSettings(
+            gp: gp,
+            designation: gpDesignation,
+            direction: null,
+            outputValue: null
+          )
+          .ModifyDacSettings(
+            dacVoltageReferenceSource: dacVoltageReferenceSource,
+            dacOutputValue: dacOutputValue
+          )
+          .ModifyAdcSettings(
+            adcVoltageReferenceSource: adcVoltageReferenceSource
+          ),
         cancellationToken: cancellationToken
       );
     }
@@ -323,6 +424,15 @@ partial class Mcp2221AGpioDriver {
       parseResponse: SetSramSettingsCommand.ParseResponse
     ).ConfigureAwait(false);
 
+    if (sramSettings.ShouldReenableVrm()) {
+      _ = await Transceiver.CommandAsync<SramSettings, None>(
+        arg: sramSettings,
+        cancellationToken: cancellationToken,
+        constructCommand: SetSramSettingsCommand.ConstructCommand,
+        parseResponse: SetSramSettingsCommand.ParseResponse
+      ).ConfigureAwait(false);
+    }
+
     // save the successfully configured settings as the current state
     sramSettings.Store();
 
@@ -346,6 +456,15 @@ partial class Mcp2221AGpioDriver {
       constructCommand: SetSramSettingsCommand.ConstructCommand,
       parseResponse: SetSramSettingsCommand.ParseResponse
     );
+
+    if (sramSettings.ShouldReenableVrm()) {
+      _ = Transceiver.Command<SramSettings, None>(
+        arg: sramSettings,
+        cancellationToken: cancellationToken,
+        constructCommand: SetSramSettingsCommand.ConstructCommand,
+        parseResponse: SetSramSettingsCommand.ParseResponse
+      );
+    }
 
     // save the successfully configured settings as the current state
     sramSettings.Store();

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/IGpControllerGroupExtensions.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/IGpControllerGroupExtensions.cs
@@ -711,5 +711,200 @@ public static class IGpControllerGroupExtensions {
         ArrayPool<PinValuePair>.Shared.Return(pinValuePairArray);
       }
     }
+
+    /// <summary>
+    /// Reads the current 10-bit raw analog values from all ADC-capable
+    /// pins (GP1, GP2, and GP3) at once.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
+    /// </param>
+    /// <returns>
+    /// A tuple containing the 10-bit raw analog values (0-1023) for
+    /// GP1, GP2, and GP3.
+    /// </returns>
+    /// <remarks>
+    /// This method calls <see cref="IGpControllerGroup.FetchAdcRawValues"/>
+    /// internally to update the analog module's state. If a pin is not
+    /// currently configured as an ADC input (see <see cref="GpFunction.Adc"/>),
+    /// the returned value for that pin is undefined.
+    /// </remarks>
+    /// <seealso cref="IGpControllerGroup.FetchAdcRawValues"/>
+    public
+    (int Gp1Value, int Gp2Value, int Gp3Value)
+    ReadAnalogRaw(
+      CancellationToken cancellationToken = default
+    )
+    {
+      ThrowIfThisArgumentIsNull(gpPins, nameof(gpPins));
+
+      return gpPins
+        .FetchAdcRawValues(
+          cancellationToken: cancellationToken
+        )
+        .AsInt32();
+    }
+
+    /// <summary>
+    /// Asynchronously reads the current 10-bit raw analog values from all
+    /// ADC-capable pins (GP1, GP2, and GP3) at once.
+    /// </summary>
+    /// <inheritdoc cref="ReadAnalogRaw(IGpControllerGroup, CancellationToken)"/>
+    /// <returns>
+    /// A <see cref="ValueTask"/> representing the asynchronous operation,
+    /// containing a tuple of the 10-bit raw analog values (0-1023) for
+    /// GP1, GP2, and GP3.
+    /// </returns>
+    /// <seealso cref="IGpControllerGroup.FetchAdcRawValuesAsync"/>
+    public
+    async ValueTask<(int Gp1Value, int Gp2Value, int Gp3Value)>
+    ReadAnalogRawAsync(
+      CancellationToken cancellationToken = default
+    )
+    {
+      ThrowIfThisArgumentIsNull(gpPins, nameof(gpPins));
+
+      return (
+        await gpPins.FetchAdcRawValuesAsync(
+          cancellationToken: cancellationToken
+        ).ConfigureAwait(false)
+      ).AsInt32();
+    }
+
+    /// <summary>
+    /// Reads the raw ADC values from all channels (GP1, GP2, and GP3) and converts
+    /// them to voltage values [V] based on the currently configured voltage
+    /// reference source (VRM).
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
+    /// </param>
+    /// <returns>
+    /// A tuple containing the voltage values [V] for GP1, GP2, and GP3.
+    /// </returns>
+    /// <remarks>
+    /// This method calls <see cref="IGpControllerGroup.FetchAdcRawValues"/>
+    /// internally to update the analog module's state. If a pin is not
+    /// currently configured as an ADC input (see <see cref="GpFunction.Adc"/>),
+    /// the returned value for that pin is undefined.
+    /// </remarks>
+    /// <inheritdoc
+    ///   cref="AdcAllChannelSample.AsVoltage(VoltageReferenceSource)"
+    ///   path="/remarks|/exception"
+    /// />
+    /// <seealso cref="IGpControllerGroup.FetchAdcRawValues"/>
+    public
+    (double Gp1Voltage, double Gp2Voltage, double Gp3Voltage)
+    ReadAnalogVoltage(
+      CancellationToken cancellationToken = default
+    )
+    {
+      ThrowIfThisArgumentIsNull(gpPins, nameof(gpPins));
+
+      return gpPins
+        .FetchAdcRawValues(
+          cancellationToken: cancellationToken
+        )
+        .AsVoltage(gpPins.CurrentAdcReferenceSource);
+    }
+
+    /// <summary>
+    /// Asynchronously reads the raw ADC values from all channels and
+    /// converts them to voltage values [V] based on the currently configured
+    /// voltage reference source(VRM).
+    /// </summary>
+    /// <inheritdoc
+    ///   cref="ReadAnalogVoltage(IGpControllerGroup, CancellationToken)"
+    ///   path="/param|/returns"
+    /// />
+    /// <inheritdoc
+    ///   cref="AdcAllChannelSample.AsVoltage(VoltageReferenceSource)"
+    /// path="/remarks|/exception"
+    /// />
+    /// <seealso cref="IGpControllerGroup.FetchAdcRawValuesAsync"/>
+    public
+    async ValueTask<(double Gp1Voltage, double Gp2Voltage, double Gp3Voltage)>
+    ReadAnalogVoltageAsync(
+      CancellationToken cancellationToken = default
+    )
+    {
+      ThrowIfThisArgumentIsNull(gpPins, nameof(gpPins));
+
+      return (
+        await gpPins.FetchAdcRawValuesAsync(
+          cancellationToken: cancellationToken
+        ).ConfigureAwait(false)
+      ).AsVoltage(gpPins.CurrentAdcReferenceSource);
+    }
+
+    /// <summary>
+    /// Reads the raw ADC values from all channels (GP1, GP2, and GP3) and converts
+    /// them to voltage values [V] based on the specified reference voltage value.
+    /// </summary>
+    /// <param name="referenceVoltage">
+    /// The reference voltage [V] used for conversion (e.g., VDD voltage).
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
+    /// </param>
+    /// <returns>
+    /// A tuple containing the voltage values [V] for GP1, GP2, and GP3.
+    /// </returns>
+    /// <remarks>
+    /// This method calls <see cref="IGpControllerGroup.FetchAdcRawValues"/>
+    /// internally to update the analog module's state. If a pin is not
+    /// currently configured as an ADC input (see <see cref="GpFunction.Adc"/>),
+    /// the returned value for that pin is undefined.
+    /// </remarks>
+    /// <inheritdoc
+    ///   cref="AdcAllChannelSample.AsVoltage(double)"
+    ///   path="/remarks|/exception"
+    /// />
+    /// <seealso cref="IGpControllerGroup.FetchAdcRawValues"/>
+    public
+    (double Gp1Voltage, double Gp2Voltage, double Gp3Voltage)
+    ReadAnalogVoltage(
+      double referenceVoltage,
+      CancellationToken cancellationToken = default
+    )
+    {
+      ThrowIfThisArgumentIsNull(gpPins, nameof(gpPins));
+
+      return gpPins
+        .FetchAdcRawValues(
+          cancellationToken: cancellationToken
+        )
+        .AsVoltage(referenceVoltage);
+    }
+
+    /// <summary>
+    /// Asynchronously reads the raw ADC values from all channels and
+    /// converts them to voltage values [V] based on the specified reference
+    /// voltage value.
+    /// </summary>
+    /// <inheritdoc
+    ///   cref="ReadAnalogVoltage(IGpControllerGroup, double, CancellationToken)"
+    ///   path="/param|/returns"
+    /// />
+    /// <inheritdoc
+    ///   cref="AdcAllChannelSample.AsVoltage(double)"
+    ///   path="/remarks|/exception"
+    /// />
+    /// <seealso cref="IGpControllerGroup.FetchAdcRawValuesAsync"/>
+    public async
+    ValueTask<(double Gp1Voltage, double Gp2Voltage, double Gp3Voltage)>
+    ReadAnalogVoltageAsync(
+      double referenceVoltage,
+      CancellationToken cancellationToken = default
+    )
+    {
+      ThrowIfThisArgumentIsNull(gpPins, nameof(gpPins));
+
+      return (
+        await gpPins.FetchAdcRawValuesAsync(
+          cancellationToken: cancellationToken
+        ).ConfigureAwait(false)
+      ).AsVoltage(referenceVoltage);
+    }
   }
 }

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221AController.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221AController.cs
@@ -81,6 +81,25 @@ public partial class Mcp2221AController :
     }
   }
 
+  /// <summary>
+  /// Gets the current voltage reference source configured for the ADC module.
+  /// </summary>
+  /// <remarks>
+  /// This property represents the global configuration for the ADC module
+  /// of the MCP2221A. Changing the reference source on one GP pin will
+  /// affect all other GP pins configured as ADC inputs.
+  /// </remarks>
+  /// <seealso cref="Gp1Controller.ConfigureAsAdc"/>
+  /// <seealso cref="Gp2Controller.ConfigureAsAdc"/>
+  /// <seealso cref="Gp3Controller.ConfigureAsAdc"/>
+  /// <seealso cref="IAdcController.CurrentAdcReferenceSource"/>
+  public VoltageReferenceSource CurrentAdcReferenceSource {
+    get {
+      ThrowIfDisposed();
+      return gpioDriver.CurrentAdcReferenceSource;
+    }
+  }
+
   private Mcp2221AController(
     Mcp2221ATransceiver transceiver,
     IMcp2221AInfo info,

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/SramSettings.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/SramSettings.cs
@@ -27,6 +27,9 @@ internal sealed class SramSettings {
   // [7] GP1 Settings
   // [8] GP2 Settings
   // [9] GP3 Settings
+  private const int OffsetOfDacVoltageReference = 1;
+  private const int OffsetOfDacOutputValue = 2;
+  private const int OffsetOfAdcVoltageReference = 3;
   private const int OffsetOfAlterGpioConfigurations = 5;
   private const int OffsetOfGpSettings = 6;
 
@@ -146,8 +149,84 @@ internal sealed class SramSettings {
     }
   }
 
+  public byte ReadAdcSettingsByte()
+    => settings[OffsetOfAdcVoltageReference];
+
   public byte ReadGpSettingsByte(int gp)
     => settings[OffsetOfGpSettings + gp];
+
+  public SramSettings ModifyDacSettings(
+    VoltageReferenceSource? dacVoltageReferenceSource,
+    int? dacOutputValue
+  )
+  {
+    if (!dacVoltageReferenceSource.HasValue && dacOutputValue.HasValue)
+      return this;
+
+    // [1] DAC Voltage Reference
+    if (dacVoltageReferenceSource.HasValue) {
+      // Bit 7: Enable loading of a new DAC reference
+      unsentSettings[OffsetOfDacVoltageReference] = 0b_1_0000_00_0;
+
+      // Bit 6-3: Don't care
+
+      // Bit 2-1: DAC V_RM voltage selection
+      // Bit 0: DAC reference voltage (1: DAC V_RM, 0: VDD)
+      unsentSettings[OffsetOfDacVoltageReference] |= GetVoltageSelectionAndReferenceVoltageBits(dacVoltageReferenceSource.Value);
+    }
+
+    // [2] Set DAC Output Value
+    if (dacOutputValue.HasValue) {
+      // Bit 7: Enable loading of a new DAC value
+      unsentSettings[OffsetOfDacOutputValue] = 0b_1_00_00000;
+
+      // Bit 6-5: Don't care
+
+      // Bit 4-0: The new DAC value
+      unsentSettings[OffsetOfDacOutputValue] |= (byte)((byte)dacOutputValue.Value & 0b_0_00_11111);
+    }
+
+    return this;
+  }
+
+  public SramSettings ModifyAdcSettings(
+    VoltageReferenceSource? adcVoltageReferenceSource
+  )
+  {
+    if (!adcVoltageReferenceSource.HasValue)
+      return this;
+
+    // [3] ADC Voltage Reference
+    // Bit 7: Enable loading of a new ADC reference
+    unsentSettings[OffsetOfAdcVoltageReference] = 0b_1_0000_00_0;
+
+    // Bit 6-3: Don't care
+
+    // Bit 2-1: ADC V_RM voltage selection
+    // Bit 0: ADC reference voltage (1: ADC V_RM, 0: VDD)
+    unsentSettings[OffsetOfAdcVoltageReference] |= GetVoltageSelectionAndReferenceVoltageBits(adcVoltageReferenceSource.Value);
+
+    return this;
+  }
+
+  private static byte GetVoltageSelectionAndReferenceVoltageBits(
+    VoltageReferenceSource voltageReferenceSource
+  )
+    // Bit 2-1: DAC/ADC V_RM voltage selection
+    // Bit 0: DAC/ADC reference voltage (1: V_RM, 0: VDD)
+    => voltageReferenceSource switch {
+      VoltageReferenceSource.Vdd => 0b_0_0000_00_0,
+
+      var vrm when vrm is
+        VoltageReferenceSource.VrmOff or
+        VoltageReferenceSource.Vrm1024 or
+        VoltageReferenceSource.Vrm2048 or
+        VoltageReferenceSource.Vrm4096 => (byte)((byte)vrm & 0b_0_0000_11_1),
+
+      var invalid => throw new NotSupportedException(
+        message: $"The voltage reference source value cannot set to {invalid}. The value must be one of the values defined in {nameof(VoltageReferenceSource)}."
+      ),
+    };
 
   public SramSettings ModifyGpSettings(
     int gp,
@@ -199,5 +278,80 @@ internal sealed class SramSettings {
 #endif
 
     return this;
+  }
+
+  /// <summary>
+  /// Determines whether the DAC/ADC Voltage Reference (VRM) needs to be re-enabled
+  /// or maintained after sending a SET SRAM SETTINGS command.
+  /// </summary>
+  /// <returns>
+  /// <see langword="true"/> if the additional command must be sent to re-enable or
+  /// maintained the VRM configuration; otherwise, <see langword="false"/>.
+  /// </returns>
+  /// <remarks>
+  /// <para>
+  /// According to the MCP2221A Datasheet (DS20005565E, Section 1.8.1.1, page 20):
+  /// "When the Set SRAM settings command is used for GPIO control, the reference
+  /// voltage for VRM is always reinitialized to the default value (VDD) if it is
+  /// not explicitly set".
+  /// </para>
+  /// <para>
+  /// This method implements a workaround for this hardware behavior. If the outgoing
+  /// command intends to alter GPIO configurations (Byte Index 7 != 0), the VRM
+  /// selection for ADC and DAC would be reset to VDD by the chip's internal logic.
+  /// </para>
+  /// <para>
+  /// To counteract this, this method checks if either the current state or the
+  /// pending settings are configured to use VRM. If VRM is in use, it ensures the
+  /// "Bit 7: Enable loading of a DAC/ADC reference" flags are set in the outgoing
+  /// command to re-assert the VRM selection, ensuring the reference does not
+  /// unexpectedly revert to VDD.
+  /// </para>
+  /// </remarks>
+  public bool ShouldReenableVrm()
+  {
+    if (unsentSettings[OffsetOfAlterGpioConfigurations] == 0)
+      // GPIO configurations will remain unaltered; no need to re-enable VRM
+      return false;
+
+    var isConfiguredToReferVrm = false;
+
+    // [1] DAC Voltage Reference
+    // Bit 7: Enable loading of a new DAC reference
+    // Bit 0: DAC reference voltage (1: DAC V_RM, 0: VDD)
+    var shouldDacVrmBeEnabled =
+      (
+        (unsentSettings[OffsetOfDacVoltageReference] & 0b_1_0000_00_0) == 0 && // DAC reference will remain unaltered, and
+        (settings[OffsetOfDacVoltageReference] & 0b_0_0000_00_1) != 0 // DAC VRM is currently enabled
+      ) || // or
+      ((unsentSettings[OffsetOfDacVoltageReference] & 0b_1_0000_00_1) == 0b_1_0000_00_1); // Altering DAC to VRM
+
+    if (shouldDacVrmBeEnabled) {
+      unsentSettings[OffsetOfDacVoltageReference] |= 0b_1_0000_00_0;
+      isConfiguredToReferVrm = true;
+    }
+
+    // [3] ADC Voltage Reference
+    // Bit 7: Enable loading of a new ADC reference
+    // Bit 0: ADC reference voltage (1: ADC V_RM, 0: VDD)
+    var shouldAdcVrmBeEnabled =
+      (
+        (unsentSettings[OffsetOfAdcVoltageReference] & 0b_1_0000_00_0) == 0 && // ADC reference will remain unaltered, and
+        (settings[OffsetOfAdcVoltageReference] & 0b_0_0000_00_1) != 0 // ADC VRM is currently enabled
+      ) || // or
+      ((unsentSettings[OffsetOfAdcVoltageReference] & 0b_1_0000_00_1) == 0b_1_0000_00_1); // Altering ADC to VRM
+
+    if (shouldAdcVrmBeEnabled) {
+      unsentSettings[OffsetOfAdcVoltageReference] |= 0b_1_0000_00_0;
+      isConfiguredToReferVrm = true;
+    }
+
+    if (isConfiguredToReferVrm) {
+      // [5] Alter GPIO configuration
+      // 0: Do not alter the current GP designation
+      unsentSettings[OffsetOfAlterGpioConfigurations] = 0;
+    }
+
+    return isConfiguredToReferVrm;
   }
 }

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/VoltageReferenceSource.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/VoltageReferenceSource.cs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+namespace Smdn.Devices.Mcp2221A;
+
+/// <summary>
+/// Specifies the voltage reference source for the DAC (Digital-to-Analog Converter)
+/// and ADC (Analog-to-Digital Converter) modules.
+/// </summary>
+/// <remarks>
+/// The MCP2221A allows independent selection of the voltage reference source for
+/// the ADC and DAC modules. Note that if an internal voltage reference (Vrm) is
+/// selected, its voltage level must be less than VDD.
+/// </remarks>
+public enum VoltageReferenceSource {
+  // The values of each member correspond to the bit 0-2 (VRM/VREF selector bits)
+  // defined in the 'Write SRAM Settings' command (0x60) of the MCP2221A.
+  // See Register 1-3 in the datasheet for more details.
+
+  /// <summary>
+  /// Uses the device's supply voltage (VDD) as the voltage reference.
+  /// </summary>
+  Vdd = 0b_0_0000_00_0,
+
+  /// <summary>
+  /// Disables the Internal Voltage Reference Module (VRM), resulting in a 0V reference.
+  /// </summary>
+  VrmOff = 0b_0_0000_00_1,
+
+  /// <summary>
+  /// Uses the Internal Voltage Reference Module (VRM) set to 1.024V.
+  /// </summary>
+  Vrm1024 = 0b_0_0000_01_1,
+
+  /// <summary>
+  /// Uses the Internal Voltage Reference Module (VRM) set to 2.048V.
+  /// </summary>
+  Vrm2048 = 0b_0_0000_10_1,
+
+  /// <summary>
+  /// Uses the Internal Voltage Reference Module (VRM) set to 4.096V.
+  /// </summary>
+  /// <remarks>
+  /// This value is only valid when VDD is greater than 4.096V (e.g., VDD is 5V).
+  /// </remarks>
+  Vrm4096 = 0b_0_0000_11_1,
+}

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/AdcAllChannelSample.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/AdcAllChannelSample.cs
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+using NUnit.Framework;
+
+namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio;
+
+[TestFixture]
+public class AdcAllChannelSampleTests {
+  private static System.Collections.IEnumerable YieldTestCases_Ctor_ArgumentOutOfRange()
+  {
+    const ushort UInt16_Zero = 0;
+    const ushort UInt16_Over10Bit = 1024;
+
+    yield return new object[] { UInt16_Over10Bit, UInt16_Zero, UInt16_Zero, "adc1", UInt16_Over10Bit };
+    yield return new object[] { ushort.MaxValue, UInt16_Zero, UInt16_Zero, "adc1", ushort.MaxValue };
+    yield return new object[] { UInt16_Zero, UInt16_Over10Bit, UInt16_Zero, "adc2", UInt16_Over10Bit };
+    yield return new object[] { UInt16_Zero, ushort.MaxValue, UInt16_Zero, "adc2", ushort.MaxValue };
+    yield return new object[] { UInt16_Zero, UInt16_Zero, UInt16_Over10Bit, "adc3", UInt16_Over10Bit };
+    yield return new object[] { UInt16_Zero, UInt16_Zero, ushort.MaxValue, "adc3", ushort.MaxValue };
+    yield return new object[] { UInt16_Over10Bit, ushort.MaxValue, UInt16_Zero, "adc1", UInt16_Over10Bit };
+    yield return new object[] { ushort.MaxValue, UInt16_Over10Bit, UInt16_Zero, "adc1", ushort.MaxValue };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_Ctor_ArgumentOutOfRange))]
+  public void Ctor_ArgumentOutOfRange(
+    ushort adc1,
+    ushort adc2,
+    ushort adc3,
+    string expectedExceptionParamName,
+    ushort expectedExceptionActualValue
+  )
+  {
+    Assert.That(
+      () => _ = new AdcAllChannelSample(adc1: adc1, adc2: adc2, adc3: adc3),
+      Throws
+        .TypeOf<ArgumentOutOfRangeException>()
+        .With
+        .Property(nameof(ArgumentOutOfRangeException.ParamName))
+        .EqualTo(expectedExceptionParamName)
+        .And
+        .Property(nameof(ArgumentOutOfRangeException.ActualValue))
+        .EqualTo(expectedExceptionActualValue)
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_AsVoltage_WithAdcVoltageReference_VrmNotOff()
+  {
+    yield return new object[] { (ushort)0, (ushort)0, (ushort)0, VoltageReferenceSource.Vrm1024, 0.0d, 0.0d, 0.0d };
+    yield return new object[] { (ushort)0, (ushort)0, (ushort)0, VoltageReferenceSource.Vrm2048, 0.0d, 0.0d, 0.0d };
+    yield return new object[] { (ushort)0, (ushort)0, (ushort)0, VoltageReferenceSource.Vrm4096, 0.0d, 0.0d, 0.0d };
+
+    yield return new object[] { (ushort)1, (ushort)0, (ushort)0, VoltageReferenceSource.Vrm1024, 0.001d, 0.0d, 0.0d };
+    yield return new object[] { (ushort)1, (ushort)1, (ushort)1, VoltageReferenceSource.Vrm1024, 0.001d, 0.001d, 0.001d };
+    yield return new object[] { (ushort)1023, (ushort)1023, (ushort)1023, VoltageReferenceSource.Vrm1024, 1.023d, 1.023d, 1.023d };
+
+    yield return new object[] { (ushort)0, (ushort)1, (ushort)0, VoltageReferenceSource.Vrm2048, 0.0d, 0.002d, 0.0d };
+    yield return new object[] { (ushort)512, (ushort)512, (ushort)1023, VoltageReferenceSource.Vrm2048, 1.024d, 1.024d, 2.046d };
+
+    yield return new object[] { (ushort)0, (ushort)0, (ushort)1, VoltageReferenceSource.Vrm4096, 0.0d, 0.0d, 0.004d };
+    yield return new object[] { (ushort)512, (ushort)1023, (ushort)1023, VoltageReferenceSource.Vrm4096, 2.048d, 4.092d, 4.092d };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_AsVoltage_WithAdcVoltageReference_VrmNotOff))]
+  public void AsVoltage_WithAdcVoltageReference_VrmNotOff(
+    ushort adc1,
+    ushort adc2,
+    ushort adc3,
+    VoltageReferenceSource adcVoltageReference,
+    double expectedAdc1Voltage,
+    double expectedAdc2Voltage,
+    double expectedAdc3Voltage
+  )
+  {
+    var expectedVoltages = (expectedAdc1Voltage, expectedAdc2Voltage, expectedAdc3Voltage);
+
+    Assert.That(
+      new AdcAllChannelSample(adc1, adc2, adc3).AsVoltage(adcVoltageReference),
+      Is.EqualTo(expectedVoltages).Within(1e-9)
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_AsVoltage_WithAdcVoltageReference_VrmOff()
+  {
+    yield return new object[] { (ushort)0, (ushort)0, (ushort)0 };
+    yield return new object[] { (ushort)1, (ushort)0, (ushort)0 };
+    yield return new object[] { (ushort)0, (ushort)2, (ushort)0 };
+    yield return new object[] { (ushort)0, (ushort)0, (ushort)3 };
+    yield return new object[] { (ushort)1023, (ushort)1023, (ushort)1023 };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_AsVoltage_WithAdcVoltageReference_VrmOff))]
+  public void AsVoltage_WithAdcVoltageReference_VrmOff(
+    ushort adc1,
+    ushort adc2,
+    ushort adc3
+  )
+  {
+    Assert.That(
+      new AdcAllChannelSample(adc1, adc2, adc3).AsVoltage(VoltageReferenceSource.VrmOff),
+      Is.Default
+    );
+  }
+
+  [Test]
+  public void AsVoltage_WithAdcVoltageReference_Vdd()
+  {
+    Assert.That(
+      () => _ = new AdcAllChannelSample().AsVoltage(VoltageReferenceSource.Vdd),
+      Throws.InvalidOperationException
+    );
+  }
+
+  [TestCase((VoltageReferenceSource)(-1))]
+  [TestCase((VoltageReferenceSource)2)]
+  [TestCase((VoltageReferenceSource)4)]
+  [TestCase((VoltageReferenceSource)6)]
+  [TestCase((VoltageReferenceSource)8)]
+  [TestCase((VoltageReferenceSource)int.MaxValue)]
+  public void AsVoltage_WithAdcVoltageReference_InvalidVoltageReferenceSource(
+    VoltageReferenceSource voltageReferenceSource
+  )
+  {
+    Assert.That(
+      () => _ = new AdcAllChannelSample().AsVoltage(voltageReferenceSource),
+      Throws.ArgumentException
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_AsVoltage_WithReferenceVoltage()
+  {
+    const double Vdd_5V0 = 5.0;
+    const double Vdd_3V3 = 3.3;
+    const double Vdd_Zero = 0.0;
+
+    yield return new object[] { (ushort)0, (ushort)0, (ushort)0, Vdd_5V0, 0.0d, 0.0d, 0.0d };
+    yield return new object[] { (ushort)512, (ushort)512, (ushort)512, Vdd_5V0, 2.5d, 2.5d, 2.5d };
+    yield return new object[] { (ushort)1023, (ushort)0, (ushort)0, Vdd_5V0, (1023.0d * 5.0d) / 1024.0, 0.0d, 0.0d };
+
+    yield return new object[] { (ushort)0, (ushort)0, (ushort)0, Vdd_3V3, 0.0d, 0.0d, 0.0d };
+    yield return new object[] { (ushort)256, (ushort)256, (ushort)256, Vdd_3V3, 0.825d, 0.825d, 0.825d };
+    yield return new object[] { (ushort)0, (ushort)1023, (ushort)0, Vdd_3V3, 0.0d, (1023.0d * 3.3d) / 1024.0d, 0.0d };
+
+    yield return new object[] { (ushort)0, (ushort)0, (ushort)0, Vdd_Zero, 0.0d, 0.0d, 0.0d };
+    yield return new object[] { (ushort)1023, (ushort)1023, (ushort)1023, Vdd_Zero, 0.0d, 0.0d, 0.0d };
+
+    yield return new object[] { (ushort)100, (ushort)500, (ushort)1000, Vdd_3V3, (100.0d * 3.3d) / 1024.0d, (500.0d * 3.3d) / 1024.0d, (1000.0d * 3.3d) / 1024.0d };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_AsVoltage_WithReferenceVoltage))]
+  public void AsVoltage_WithReferenceVoltage(
+    ushort adc1,
+    ushort adc2,
+    ushort adc3,
+    double referenceVoltage,
+    double expectedAdc1Voltage,
+    double expectedAdc2Voltage,
+    double expectedAdc3Voltage
+  )
+  {
+    var expectedVoltages = (expectedAdc1Voltage, expectedAdc2Voltage, expectedAdc3Voltage);
+
+    Assert.That(
+      new AdcAllChannelSample(adc1, adc2, adc3).AsVoltage(referenceVoltage),
+      Is.EqualTo(expectedVoltages).Within(1e-9)
+    );
+  }
+
+  [TestCase(-1.0)]
+  [TestCase(double.MinValue)]
+  // [TestCase(double.NegativeZero)]
+  [TestCase(double.NegativeInfinity)]
+  [TestCase(double.PositiveInfinity)]
+  [TestCase(double.NaN)]
+  public void AsVoltage_WithReferenceVoltage_InvalidReferenceVoltage(
+    double referenceVoltage
+  )
+  {
+    Assert.That(
+      () => new AdcAllChannelSample().AsVoltage(referenceVoltage: referenceVoltage),
+      Throws
+        .InstanceOf<ArgumentException>()
+        .With
+        .Property(nameof(ArgumentException.ParamName))
+        .EqualTo(nameof(referenceVoltage))
+    );
+  }
+}

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IAdcController.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IAdcController.cs
@@ -1,0 +1,809 @@
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using Smdn.IO.UsbHid;
+
+using SequenceIs = Smdn.Test.NUnit.Constraints.Buffers.Is;
+
+namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio;
+
+#pragma warning disable IDE0040
+partial class GpControllerTests {
+#pragma warning restore IDE0040
+  private static System.Collections.IEnumerable YieldTestCases_ConfigureAsAdcSyncOrAsync()
+  {
+    const byte InitialChipSettings3_AdcVrm = 0b_0_1_1_01_1_00; // ADC: VRM 1.024V (factory default)
+    const byte InitialChipSettings3_AdcVdd = 0b_0_1_1_00_0_00; // ADC: VDD
+
+    for (var gpIndex = 1; gpIndex <= 3; gpIndex++) {
+      yield return new object[] { gpIndex, InitialChipSettings3_AdcVrm, VoltageReferenceSource.Vdd };
+      yield return new object[] { gpIndex, InitialChipSettings3_AdcVrm, VoltageReferenceSource.VrmOff };
+      yield return new object[] { gpIndex, InitialChipSettings3_AdcVrm, VoltageReferenceSource.Vrm1024 };
+      yield return new object[] { gpIndex, InitialChipSettings3_AdcVrm, VoltageReferenceSource.Vrm2048 };
+      yield return new object[] { gpIndex, InitialChipSettings3_AdcVrm, VoltageReferenceSource.Vrm4096 };
+
+      yield return new object[] { gpIndex, InitialChipSettings3_AdcVdd, VoltageReferenceSource.Vdd };
+      yield return new object[] { gpIndex, InitialChipSettings3_AdcVdd, VoltageReferenceSource.VrmOff };
+      yield return new object[] { gpIndex, InitialChipSettings3_AdcVdd, VoltageReferenceSource.Vrm1024 };
+      yield return new object[] { gpIndex, InitialChipSettings3_AdcVdd, VoltageReferenceSource.Vrm2048 };
+      yield return new object[] { gpIndex, InitialChipSettings3_AdcVdd, VoltageReferenceSource.Vrm4096 };
+    }
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ConfigureAsAdcSyncOrAsync))]
+  public void ConfigureAsAdcAsync(
+    int gpIndex,
+    byte initialChipSettings3,
+    VoltageReferenceSource voltageReferenceSource
+  )
+    => ConfigureAsAdcSyncOrAsync(
+      gpIndex,
+      initialChipSettings3,
+      voltageReferenceSource,
+      static async (gp, vr) => await ((IAdcController)gp).ConfigureAsAdcAsync(voltageReferenceSource: vr).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ConfigureAsAdcSyncOrAsync))]
+  public void ConfigureAsAdc(
+    int gpIndex,
+    byte initialChipSettings3,
+    VoltageReferenceSource voltageReferenceSource
+  )
+    => ConfigureAsAdcSyncOrAsync(
+      gpIndex,
+      initialChipSettings3,
+      voltageReferenceSource,
+      static (gp, vr) => {
+        ((IAdcController)gp).ConfigureAsAdc(voltageReferenceSource: vr);
+        return default;
+      }
+    );
+
+  private void ConfigureAsAdcSyncOrAsync(
+    int gpIndex,
+    byte initialChipSettings3,
+    VoltageReferenceSource voltageReferenceSource,
+    Func<GpController, VoltageReferenceSource, ValueTask> configureAsAdcAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings3: initialChipSettings3
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    var expectedAssignments = mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList();
+    var currentGpSettings = new byte[4] { InitialGp0Settings, InitialGp1Settings, InitialGp2Settings, InitialGp3Settings };
+
+    if (voltageReferenceSource == VoltageReferenceSource.Vdd) {
+      Mcp2221AControllerTests.AppendPseudoResponse(
+        mcp2221A,
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+      );
+    }
+    else {
+      Mcp2221AControllerTests.AppendPseudoResponse(
+        mcp2221A,
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62)),
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS (response to the command to re-enable VRM)
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+      );
+    }
+
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    expectedAssignments[gpIndex] = GpFunction.Adc;
+
+    var expectedVoltageReferenceBits = voltageReferenceSource switch {
+      VoltageReferenceSource.Vdd => 0b_0_0000_00_0,
+      VoltageReferenceSource.VrmOff => 0b_0_0000_00_1,
+      VoltageReferenceSource.Vrm1024 => 0b_0_0000_01_1,
+      VoltageReferenceSource.Vrm2048 => 0b_0_0000_10_1,
+      VoltageReferenceSource.Vrm4096 => 0b_0_0000_11_1,
+      _ => throw new InvalidOperationException(),
+    };
+    const byte ExpectedDesignationBits = 0b_000_0_0_010; // ADC1/ADC2/ADC3
+
+    currentGpSettings[gpIndex] = (byte)((currentGpSettings[gpIndex] & 0b_1_1111_00_0) | ExpectedDesignationBits);
+
+    var expectedSentSramSettingsCommand = new byte[64];
+
+    expectedSentSramSettingsCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+    // [1-4] don't care
+    expectedSentSramSettingsCommand[5] = (byte)(0b10000000 | expectedVoltageReferenceBits); // [5] ADC Voltage Reference
+    // [6] don't care
+    expectedSentSramSettingsCommand[7] = 0b10000000; // [7] Alter GPIO configuration = Alter the GP designation (1)
+    expectedSentSramSettingsCommand[8] = currentGpSettings[0]; // [8] GP0 settings
+    expectedSentSramSettingsCommand[9] = currentGpSettings[1]; // [9] GP1 settings
+    expectedSentSramSettingsCommand[10] = currentGpSettings[2]; // [10] GP2 settings
+    expectedSentSramSettingsCommand[11] = currentGpSettings[3]; // [11] GP3 settings
+
+    var expectedSentReenableVrmCommand = new byte[64];
+
+    expectedSentReenableVrmCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+    // [1-4] don't care
+    expectedSentReenableVrmCommand[5] = (byte)(0b10000000 | expectedVoltageReferenceBits); // [5] ADC Voltage Reference
+    // [6] don't care
+    expectedSentReenableVrmCommand[7] = 0b00000000; // [7] Alter GPIO configuration = Do not alter the current GP designation (0)
+    expectedSentReenableVrmCommand[8] = currentGpSettings[0]; // [8] GP0 settings
+    expectedSentReenableVrmCommand[9] = currentGpSettings[1]; // [9] GP1 settings
+    expectedSentReenableVrmCommand[10] = currentGpSettings[2]; // [10] GP2 settings
+    expectedSentReenableVrmCommand[11] = currentGpSettings[3]; // [11] GP3 settings
+
+    Assert.That(
+      async () => await configureAsAdcAsyncFunc(mcp2221A.GpPins[gpIndex], voltageReferenceSource),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A, 0),
+      SequenceIs.EqualTo(expectedSentSramSettingsCommand)
+    );
+
+    if (voltageReferenceSource != VoltageReferenceSource.Vdd) {
+      Assert.That(
+        Mcp2221AControllerTests.GetSentCommand(mcp2221A, 1),
+        SequenceIs.EqualTo(expectedSentReenableVrmCommand)
+      );
+    }
+
+    Assert.That(mcp2221A.CurrentAdcReferenceSource, Is.EqualTo(voltageReferenceSource));
+
+    Assert.That(mcp2221A.GpPins[gpIndex].CurrentFunction, Is.EqualTo(GpFunction.Adc));
+    Assert.That(((IAdcController)mcp2221A.GpPins[gpIndex]).CurrentAdcReferenceSource, Is.EqualTo(voltageReferenceSource));
+
+    Assert.That(
+      mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList(),
+      Is.EqualTo(expectedAssignments).AsCollection,
+      $"other GP pins must not be configured (except {mcp2221A.GpPins[gpIndex].PinName})"
+    );
+  }
+
+  private static IEnumerable<VoltageReferenceSource> YieldTestCases_UnsupportedVoltageReferenceSource()
+  {
+    yield return (VoltageReferenceSource)(-1);
+    yield return (VoltageReferenceSource)0b_0_0000_01_0; // VRM 4.096 + ADC voltage reference is VDD
+    yield return (VoltageReferenceSource)0b_0_0000_10_0; // VRM 2.048 + ADC voltage reference is VDD
+    yield return (VoltageReferenceSource)0b_0_0000_11_0; // VRM 1.024 + ADC voltage reference is VDD
+    yield return (VoltageReferenceSource)0b_1_1111_00_0;
+    yield return (VoltageReferenceSource)0b_1_1111_11_1;
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_UnsupportedVoltageReferenceSource))]
+  public void ConfigureAsAdcAsync_UnsupportedVoltageReferenceSource(VoltageReferenceSource voltageReferenceSource)
+    => ConfigureAsAdcSyncOrAsync_UnsupportedVoltageReferenceSource(
+      voltageReferenceSource,
+      static async (gp, vr) => await ((IAdcController)gp).ConfigureAsAdcAsync(voltageReferenceSource: vr).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_UnsupportedVoltageReferenceSource))]
+  public void ConfigureAsAdc_UnsupportedVoltageReferenceSource(VoltageReferenceSource voltageReferenceSource)
+    => ConfigureAsAdcSyncOrAsync_UnsupportedVoltageReferenceSource(
+      voltageReferenceSource,
+      static (gp, vr) => {
+        ((IAdcController)gp).ConfigureAsAdc(voltageReferenceSource: vr);
+        return default;
+      }
+    );
+
+  private void ConfigureAsAdcSyncOrAsync_UnsupportedVoltageReferenceSource(
+    VoltageReferenceSource voltageReferenceSource,
+    Func<GpController, VoltageReferenceSource, ValueTask> configureAsAdcAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+    const byte InitialChipSettings3 = 0b_0_1_1_01_1_00; // ADC: VRM 1.024V (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings3: InitialChipSettings3
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    var initialAssignments = mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList();
+    var initialAdcReferenceSource = mcp2221A.CurrentAdcReferenceSource;
+
+    foreach (var gp in new GpController[] { mcp2221A.GpPin1, mcp2221A.GpPin2, mcp2221A.GpPin3 }) {
+      Assert.That(
+        async () => await configureAsAdcAsyncFunc(gp, voltageReferenceSource),
+        Throws.TypeOf<NotSupportedException>(),
+        $"unsupported voltage reference source ({gp.PinName}, {voltageReferenceSource})"
+      );
+
+      Assert.That(
+        mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList(),
+        Is.EqualTo(initialAssignments).AsCollection,
+        $"must not be configured ({gp.PinName})"
+      );
+
+      Assert.That(
+        mcp2221A.CurrentAdcReferenceSource,
+        Is.EqualTo(initialAdcReferenceSource),
+        $"must not be configured ({nameof(mcp2221A.CurrentAdcReferenceSource)})"
+      );
+    }
+  }
+
+  [Test]
+  public void ConfigureAsAdcAsync_CancellationRequested()
+    => ConfigureAsAdcSyncOrAsync_CancellationRequested(
+      static async (gp, ct) => await ((IAdcController)gp).ConfigureAsAdcAsync(VoltageReferenceSource.Vdd, cancellationToken: ct).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void ConfigureAsAdc_CancellationRequested()
+    => ConfigureAsAdcSyncOrAsync_CancellationRequested(
+      static (gp, ct) => {
+        ((IAdcController)gp).ConfigureAsAdc(VoltageReferenceSource.Vdd, cancellationToken: ct);
+        return default;
+      }
+    );
+
+  private void ConfigureAsAdcSyncOrAsync_CancellationRequested(
+    Func<GpController, CancellationToken, ValueTask> configureAsAdcAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+    const byte InitialChipSettings3 = 0b_0_1_1_01_1_00; // ADC: VRM 1.024V (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings3: InitialChipSettings3
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    var initialAssignments = mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList();
+    var initialAdcReferenceSource = mcp2221A.CurrentAdcReferenceSource;
+
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    foreach (var gp in new GpController[] { mcp2221A.GpPin1, mcp2221A.GpPin2, mcp2221A.GpPin3 }) {
+      Assert.That(
+        async () => await configureAsAdcAsyncFunc(gp, cts.Token),
+        Throws
+          .TypeOf<OperationCanceledException>()
+          .With
+          .Property(nameof(OperationCanceledException.CancellationToken))
+          .EqualTo(cts.Token),
+        $"cancellation requested ({gp.PinName})"
+      );
+
+      Assert.That(
+        mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList(),
+        Is.EqualTo(initialAssignments).AsCollection,
+        $"must not be configured ({gp.PinName})"
+      );
+
+      Assert.That(
+        mcp2221A.CurrentAdcReferenceSource,
+        Is.EqualTo(initialAdcReferenceSource),
+        $"must not be configured ({nameof(mcp2221A.CurrentAdcReferenceSource)})"
+      );
+    }
+  }
+
+  [Test]
+  public void ConfigureAsAdcAsync_Disposed()
+    => ConfigureAsAdcSyncOrAsync_Disposed(
+      static async gp => await ((IAdcController)gp).ConfigureAsAdcAsync(VoltageReferenceSource.Vdd).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void ConfigureAsAdc_Disposed()
+    => ConfigureAsAdcSyncOrAsync_Disposed(
+      static gp => {
+        ((IAdcController)gp).ConfigureAsAdc(VoltageReferenceSource.Vdd);
+        return default;
+      }
+    );
+
+  private void ConfigureAsAdcSyncOrAsync_Disposed(
+    Func<GpController, ValueTask> configureAsAdcAsyncFunc
+  )
+  {
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true
+    );
+    var adcPins = new GpController[] { mcp2221A.GpPin1, mcp2221A.GpPin2, mcp2221A.GpPin3 };
+
+    mcp2221A.Dispose();
+
+    foreach (var gp in adcPins) {
+      Assert.That(
+        async () => await configureAsAdcAsyncFunc(gp),
+        Throws.TypeOf<ObjectDisposedException>(),
+        $"object disposed ({gp.PinName})"
+      );
+    }
+  }
+
+  private static IEnumerable<byte> YieldTestCases_ReadAnalogRawSyncAndAsync_GP1_InvalidConfiguration()
+  {
+    yield return 0b_000_1_0_000; // GPIO1
+    yield return 0b_000_1_0_100; // IOC
+    yield return 0b_000_1_0_011; // LED_UTX
+    yield return 0b_000_1_0_001; // CLK OUT
+  }
+
+  private static IEnumerable<byte> YieldTestCases_ReadAnalogRawSyncAndAsync_GP2_InvalidConfiguration()
+  {
+    yield return 0b_000_1_0_000; // GPIO2
+    yield return 0b_000_1_0_011; // DAC1
+    yield return 0b_000_1_0_001; // USBCFG
+  }
+
+  private static IEnumerable<byte> YieldTestCases_ReadAnalogRawSyncAndAsync_GP3_InvalidConfiguration()
+  {
+    yield return 0b_000_1_0_000; // GPIO3
+    yield return 0b_000_1_0_011; // DAC2
+    yield return 0b_000_1_0_001; // LED_I2C
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncAndAsync_GP1_InvalidConfiguration))]
+  public void ReadAnalogRawAsync_GP1_InvalidConfiguration(byte gp1Settings)
+    => ReadAnalogRawSyncAndAsync_InvalidConfiguration(
+      gp1Settings: gp1Settings,
+      gp2Settings: null,
+      gp3Settings: null,
+      expectedAdcPinNumberInExceptionMessage: 1,
+      static async mcp2221a => _ = await mcp2221a.GpPin1.ReadAnalogRawAsync().ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncAndAsync_GP1_InvalidConfiguration))]
+  public void ReadAnalogRaw_GP1_InvalidConfiguration(byte gp1Settings)
+    => ReadAnalogRawSyncAndAsync_InvalidConfiguration(
+      gp1Settings: gp1Settings,
+      gp2Settings: null,
+      gp3Settings: null,
+      expectedAdcPinNumberInExceptionMessage: 1,
+      static mcp2221a => {
+        _ = mcp2221a.GpPin1.ReadAnalogRaw();
+        return default;
+      }
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncAndAsync_GP2_InvalidConfiguration))]
+  public void ReadAnalogRawAsync_GP2_InvalidConfiguration(byte gp2Settings)
+    => ReadAnalogRawSyncAndAsync_InvalidConfiguration(
+      gp1Settings: null,
+      gp2Settings: gp2Settings,
+      gp3Settings: null,
+      expectedAdcPinNumberInExceptionMessage: 2,
+      static async mcp2221a => _ = await mcp2221a.GpPin2.ReadAnalogRawAsync().ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncAndAsync_GP2_InvalidConfiguration))]
+  public void ReadAnalogRaw_GP2_InvalidConfiguration(byte gp2Settings)
+    => ReadAnalogRawSyncAndAsync_InvalidConfiguration(
+      gp1Settings: null,
+      gp2Settings: gp2Settings,
+      gp3Settings: null,
+      expectedAdcPinNumberInExceptionMessage: 2,
+      static mcp2221a => {
+        _ = mcp2221a.GpPin2.ReadAnalogRaw();
+        return default;
+      }
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncAndAsync_GP3_InvalidConfiguration))]
+  public void ReadAnalogRawAsync_GP3_InvalidConfiguration(byte gp3Settings)
+    => ReadAnalogRawSyncAndAsync_InvalidConfiguration(
+      gp1Settings: null,
+      gp2Settings: null,
+      gp3Settings: gp3Settings,
+      expectedAdcPinNumberInExceptionMessage: 3,
+      static async mcp2221a => _ = await mcp2221a.GpPin3.ReadAnalogRawAsync().ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncAndAsync_GP3_InvalidConfiguration))]
+  public void ReadAnalogRaw_GP3_InvalidConfiguration(byte gp3Settings)
+    => ReadAnalogRawSyncAndAsync_InvalidConfiguration(
+      gp1Settings: null,
+      gp2Settings: null,
+      gp3Settings: gp3Settings,
+      expectedAdcPinNumberInExceptionMessage: 3,
+      static mcp2221a => {
+        _ = mcp2221a.GpPin3.ReadAnalogRaw();
+        return default;
+      }
+    );
+
+  private void ReadAnalogRawSyncAndAsync_InvalidConfiguration(
+    byte? gp1Settings,
+    byte? gp2Settings,
+    byte? gp3Settings,
+    int expectedAdcPinNumberInExceptionMessage,
+    Func<Mcp2221AController, ValueTask> readAnalogRawAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+    const byte InitialChipSettings3 = 0b_0_1_1_01_1_00; // ADC: VRM 1.024V (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: gp1Settings ?? InitialGp1Settings,
+        gp2Settings: gp2Settings ?? InitialGp2Settings,
+        gp3Settings: gp3Settings ?? InitialGp3Settings,
+        chipSettings3: InitialChipSettings3
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    Assert.That(
+      async () => await readAnalogRawAsyncFunc(mcp2221A),
+      Throws
+        .InvalidOperationException
+        .With
+        .Property(nameof(InvalidOperationException.Message))
+        .Contains($"GP{expectedAdcPinNumberInExceptionMessage}")
+    );
+  }
+
+  [Test]
+  public void ReadAnalogRawAsync_Disposed()
+    => ReadAnalogRawSyncOrAsync_Disposed(
+      static async gp => { _ = await ((IAdcController)gp).ReadAnalogRawAsync().ConfigureAwait(false); }
+    );
+
+  [Test]
+  public void ReadAnalogRaw_Disposed()
+    => ReadAnalogRawSyncOrAsync_Disposed(
+      static gp => {
+        _ = ((IAdcController)gp).ReadAnalogRaw();
+        return default;
+      }
+    );
+
+  private void ReadAnalogRawSyncOrAsync_Disposed(
+    Func<GpController, ValueTask> readAnalogRawAsyncFunc
+  )
+  {
+    using var mcp2221A = CreateMcp2221AConfiguredAsAdc();
+    var adcPins = new GpController[] { mcp2221A.GpPin1, mcp2221A.GpPin2, mcp2221A.GpPin3 };
+
+    mcp2221A.Dispose();
+
+    foreach (var gp in adcPins) {
+      Assert.That(
+        async () => await readAnalogRawAsyncFunc(gp),
+        Throws.TypeOf<ObjectDisposedException>(),
+        $"object disposed ({gp.PinName})"
+      );
+    }
+  }
+
+  [Test]
+  public void ReadAnalogRawAsync_CancellationRequested()
+    => ReadAnalogRawSyncOrAsync_CancellationRequested(
+      static async (gp, ct) => { _ = await ((IAdcController)gp).ReadAnalogRawAsync(ct).ConfigureAwait(false); }
+    );
+
+  [Test]
+  public void ReadAnalogRaw_CancellationRequested()
+    => ReadAnalogRawSyncOrAsync_CancellationRequested(
+      static (gp, ct) => {
+        _ = ((IAdcController)gp).ReadAnalogRaw(ct);
+        return default;
+      }
+    );
+
+  private void ReadAnalogRawSyncOrAsync_CancellationRequested(
+    Func<GpController, CancellationToken, ValueTask> readAnalogRawAsyncFunc
+  )
+  {
+    using var mcp2221A = CreateMcp2221AConfiguredAsAdc();
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    foreach (var gp in new GpController[] { mcp2221A.GpPin1, mcp2221A.GpPin2, mcp2221A.GpPin3 }) {
+      Assert.That(
+        async () => await readAnalogRawAsyncFunc(gp, cts.Token),
+        Throws
+          .TypeOf<OperationCanceledException>()
+          .With
+          .Property(nameof(OperationCanceledException.CancellationToken))
+          .EqualTo(cts.Token),
+        $"cancellation requested ({gp.PinName})"
+      );
+    }
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_ReadAnalogRawSyncOrAsync()
+  {
+    yield return new object[] { "00-00-", "00-00-", "00-00-", 0x_00_00, 0x_00_00, 0x_00_00 };
+    yield return new object[] { "FF-03-", "FF-03-", "FF-03-", 0x_03_FF, 0x_03_FF, 0x_03_FF };
+    yield return new object[] { "23-01-", "46-02-", "69-03-", 0x_01_23, 0x_02_46, 0x_03_69 };
+
+    yield return new object[] { "00-03-", "00-00-", "00-00-", 0x_03_00, 0x_00_00, 0x_00_00 };
+    yield return new object[] { "00-00-", "00-03-", "00-00-", 0x_00_00, 0x_03_00, 0x_00_00 };
+    yield return new object[] { "00-00-", "00-00-", "00-03-", 0x_00_00, 0x_00_00, 0x_03_00 };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncOrAsync))]
+  public ValueTask ReadAnalogRawAsync_GP1(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue
+  )
+    => ReadAnalogRawSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdcRawValue: expectedAdc1RawValue,
+      static async mcp2221a => await mcp2221a.GpPin1.ReadAnalogRawAsync().ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncOrAsync))]
+  public ValueTask ReadAnalogRaw_GP1(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue
+  )
+    => ReadAnalogRawSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdcRawValue: expectedAdc1RawValue,
+      static mcp2221a => new(mcp2221a.GpPin1.ReadAnalogRaw())
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncOrAsync))]
+  public ValueTask ReadAnalogRawAsync_GP2(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue
+  )
+    => ReadAnalogRawSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdcRawValue: expectedAdc2RawValue,
+      static async mcp2221a => await mcp2221a.GpPin2.ReadAnalogRawAsync().ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncOrAsync))]
+  public ValueTask ReadAnalogRaw_GP2(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue
+  )
+    => ReadAnalogRawSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdcRawValue: expectedAdc2RawValue,
+      static mcp2221a => new(mcp2221a.GpPin2.ReadAnalogRaw())
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncOrAsync))]
+  public ValueTask ReadAnalogRawAsync_GP3(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue
+  )
+    => ReadAnalogRawSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdcRawValue: expectedAdc3RawValue,
+      static async mcp2221a => await mcp2221a.GpPin3.ReadAnalogRawAsync().ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncOrAsync))]
+  public ValueTask ReadAnalogRaw_GP3(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue
+  )
+    => ReadAnalogRawSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdcRawValue: expectedAdc3RawValue,
+      static mcp2221a => new(mcp2221a.GpPin3.ReadAnalogRaw())
+    );
+
+  private async ValueTask ReadAnalogRawSyncOrAsync(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdcRawValue,
+    Func<Mcp2221AController, ValueTask<int>> readAnalogRawAsyncFunc
+  )
+  {
+    using var mcp2221A = CreateMcp2221AConfiguredAsAdc();
+
+    // [MCP2221A] 3.1.1 STATUS/SET PARAMETERS
+    var statusSetParametersResponse = string.Concat(
+      "10-00-",
+      string.Join("-", Enumerable.Repeat("00", 50 - 2)), "-",
+      // [50-55] ADC Data (16-bit) values
+      adcChannel0Response, // [50] LSB [51] MSB of ADC CH0
+      adcChannel1Response, // [52] LSB [53] MSB of ADC CH1
+      adcChannel2Response, // [54] LSB [55] MSB of ADC CH2
+      string.Join("-", Enumerable.Repeat("00", 64 - 56))
+    );
+
+    Mcp2221AControllerTests.AppendPseudoResponse(mcp2221A, statusSetParametersResponse);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    var expectedSentCommand = new byte[64]; // [1-64]: don't care
+
+    expectedSentCommand[0] = 0x10; // STATUS/SET PARAMETERS
+
+    Assert.That(
+      await readAnalogRawAsyncFunc(mcp2221A),
+      Is.EqualTo(expectedAdcRawValue)
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A),
+      SequenceIs.EqualTo(expectedSentCommand),
+      $"sent command from {nameof(IAdcController.ReadAnalogRaw)}"
+    );
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncOrAsync))]
+  public void LastReadAnalogRawValue_AfterReadAnalogRawAsync(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue
+  )
+    => LastReadAnalogRawValue(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdc1RawValue: expectedAdc1RawValue,
+      expectedAdc2RawValue: expectedAdc2RawValue,
+      expectedAdc3RawValue: expectedAdc3RawValue,
+      static async gp => { _ = await ((IAdcController)gp).ReadAnalogRawAsync().ConfigureAwait(false); }
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncOrAsync))]
+  public void LastReadAnalogRawValue_AfterReadAnalogRaw(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue
+  )
+    => LastReadAnalogRawValue(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdc1RawValue: expectedAdc1RawValue,
+      expectedAdc2RawValue: expectedAdc2RawValue,
+      expectedAdc3RawValue: expectedAdc3RawValue,
+      static gp => {
+        _ = ((IAdcController)gp).ReadAnalogRaw();
+        return default;
+      }
+    );
+
+  private void LastReadAnalogRawValue(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue,
+    Func<GpController, ValueTask> readAnalogRawAsyncFunc
+  )
+  {
+    for (var gpIndex = 1; gpIndex <= 3; gpIndex++) {
+      using var mcp2221A = CreateMcp2221AConfiguredAsAdc();
+      var gp = mcp2221A.GpPins[gpIndex];
+
+      // [MCP2221A] 3.1.1 STATUS/SET PARAMETERS
+      var statusSetParametersResponse = string.Concat(
+        "10-00-",
+        string.Join("-", Enumerable.Repeat("00", 50 - 2)), "-",
+        // [50-55] ADC Data (16-bit) values
+        adcChannel0Response, // [50] LSB [51] MSB of ADC CH0
+        adcChannel1Response, // [52] LSB [53] MSB of ADC CH1
+        adcChannel2Response, // [54] LSB [55] MSB of ADC CH2
+        string.Join("-", Enumerable.Repeat("00", 64 - 56))
+      );
+
+      Mcp2221AControllerTests.AppendPseudoResponse(mcp2221A, statusSetParametersResponse);
+      Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+      var expectedSentCommand = new byte[64]; // [1-64]: don't care
+
+      expectedSentCommand[0] = 0x10; // STATUS/SET PARAMETERS
+
+      Assert.That(
+        async () => await readAnalogRawAsyncFunc(gp),
+        Throws.Nothing,
+        $"ReadAnalogRaw {gp.PinName}"
+      );
+
+      Assert.That(
+        Mcp2221AControllerTests.GetSentCommand(mcp2221A),
+        SequenceIs.EqualTo(expectedSentCommand),
+        $"sent command from {nameof(IAdcController.ReadAnalogRaw)} ({gp.PinName})"
+      );
+
+      Assert.That(
+        mcp2221A.GpPin1.LastReadAnalogRawValue,
+        Is.EqualTo(expectedAdc1RawValue)
+      );
+      Assert.That(
+        mcp2221A.GpPin2.LastReadAnalogRawValue,
+        Is.EqualTo(expectedAdc2RawValue)
+      );
+      Assert.That(
+        mcp2221A.GpPin3.LastReadAnalogRawValue,
+        Is.EqualTo(expectedAdc3RawValue)
+      );
+    }
+  }
+}

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IGpioController.SetSramSettings.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IGpioController.SetSramSettings.cs
@@ -54,13 +54,15 @@ partial class GpControllerTests {
     const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
     const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
     const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+    const byte InitialChipSettings3 = 0b_0_1_1_00_0_00; // ADC: VDD
 
     using var mcp2221A = Mcp2221AController.Create(
       Mcp2221AControllerTests.CreatePseudoDevice(
         gp0Settings: InitialGp0Settings,
         gp1Settings: InitialGp1Settings,
         gp2Settings: InitialGp2Settings,
-        gp3Settings: InitialGp3Settings
+        gp3Settings: InitialGp3Settings,
+        chipSettings3: InitialChipSettings3
       ),
       shouldDisposeUsbHidDevice: true
     );
@@ -109,6 +111,134 @@ partial class GpControllerTests {
       Assert.That(
         Mcp2221AControllerTests.GetSentCommand(mcp2221A),
         SequenceIs.EqualTo(expectedSentCommand)
+      );
+
+      Assert.That(gp.CurrentFunction, Is.EqualTo(GpFunction.Gpio));
+      Assert.That(gp.CurrentMode, Is.EqualTo(mode));
+      Assert.That(gp.LastUpdatedValue, Is.EqualTo(initialValue));
+
+      Assert.That(
+        mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList(),
+        Is.EqualTo(expectedAssignments).AsCollection,
+        $"other GP pins must not be configured (except {gp.PinName})"
+      );
+    }
+  }
+
+  [TestCase(PinMode.Input, true)]
+  [TestCase(PinMode.Input, false)]
+  [TestCase(PinMode.Output, true)]
+  [TestCase(PinMode.Output, false)]
+  public void ConfigureAsGpioAsync_AdcVmrMustBeReenabled(PinMode mode, bool initialValue)
+    => ConfigureAsGpioSyncOrAsync_AdcVmrMustBeReenabled(
+      mode,
+      (PinValue)initialValue,
+      static async (gp, m, val) => await gp.ConfigureAsGpioAsync(mode: m, initialValue: val).ConfigureAwait(false)
+    );
+
+  [TestCase(PinMode.Input, true)]
+  [TestCase(PinMode.Input, false)]
+  [TestCase(PinMode.Output, true)]
+  [TestCase(PinMode.Output, false)]
+  public void ConfigureAsGpio_AdcVmrMustBeReenabled(PinMode mode, bool initialValue)
+    => ConfigureAsGpioSyncOrAsync_AdcVmrMustBeReenabled(
+      mode,
+      (PinValue)initialValue,
+      static (gp, m, val) => {
+        gp.ConfigureAsGpio(mode: m, initialValue: val);
+        return default;
+      }
+    );
+
+  private void ConfigureAsGpioSyncOrAsync_AdcVmrMustBeReenabled(
+    PinMode mode,
+    PinValue initialValue,
+    Func<GpController, PinMode, PinValue, ValueTask> configureAsGpioAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+    const byte InitialChipSettings3 = 0b_0_1_1_01_1_00; // ADC: VRM 1.024V (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings3: InitialChipSettings3
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    var expectedAssignments = mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList();
+    var currentGpSettings = new byte[4] { InitialGp0Settings, InitialGp1Settings, InitialGp2Settings, InitialGp3Settings };
+
+    foreach (var gp in mcp2221A.GpPins) {
+      Mcp2221AControllerTests.AppendPseudoResponse(
+        mcp2221A,
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62)),
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS (response to the command to re-enable VRM)
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+      );
+      Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+      expectedAssignments[gp.Index] = GpFunction.Gpio;
+
+      var expectedOutputValueBits = (bool)initialValue switch {
+        true => 0b_000_1_0_000,
+        false => 0b_000_0_0_000,
+      };
+      var expectedDirectionBits = mode switch {
+        PinMode.Input => 0b_000_0_1_000,
+        PinMode.Output => 0b_000_0_0_000,
+        _ => throw new InvalidOperationException(),
+      };
+      const byte ExpectedDesignationBits = 0b_000_0_0_000; // GPIO operation
+
+      currentGpSettings[gp.Index] = (byte)(expectedOutputValueBits | expectedDirectionBits | ExpectedDesignationBits);
+
+      var expectedSentSramSettingsCommand = new byte[64];
+
+      expectedSentSramSettingsCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+      // [1-4] don't care
+      expectedSentSramSettingsCommand[5] = 0b_0_0000_01_1; // [5] ADC Voltage Reference: VRM 1.024V
+      // [1-6] don't care
+      expectedSentSramSettingsCommand[7] = 0b10000000; // [7] Alter GPIO configuration = Alter the GP designation (1)
+      expectedSentSramSettingsCommand[8] = currentGpSettings[0]; // [8] GP0 settings
+      expectedSentSramSettingsCommand[9] = currentGpSettings[1]; // [9] GP1 settings
+      expectedSentSramSettingsCommand[10] = currentGpSettings[2]; // [10] GP2 settings
+      expectedSentSramSettingsCommand[11] = currentGpSettings[3]; // [11] GP3 settings
+
+      var expectedSentReenableVrmCommand = new byte[64];
+
+      expectedSentReenableVrmCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+      // [1-4] don't care
+      expectedSentReenableVrmCommand[5] = 0b_1_0000_01_1; // [5] ADC Voltage Reference: VRM 1.024V
+      // [6] don't care
+      expectedSentReenableVrmCommand[7] = 0b00000000; // [7] Alter GPIO configuration = Do not alter the current GP designation (0)
+      expectedSentReenableVrmCommand[8] = currentGpSettings[0]; // [8] GP0 settings
+      expectedSentReenableVrmCommand[9] = currentGpSettings[1]; // [9] GP1 settings
+      expectedSentReenableVrmCommand[10] = currentGpSettings[2]; // [10] GP2 settings
+      expectedSentReenableVrmCommand[11] = currentGpSettings[3]; // [11] GP3 settings
+
+      Assert.That(
+        async () => await configureAsGpioAsyncFunc(gp, mode, initialValue),
+        Throws.Nothing
+      );
+      Assert.That(
+        Mcp2221AControllerTests.GetSentCommand(mcp2221A, 0),
+        SequenceIs.EqualTo(expectedSentSramSettingsCommand)
+      );
+      Assert.That(
+        Mcp2221AControllerTests.GetSentCommand(mcp2221A, 1),
+        SequenceIs.EqualTo(expectedSentReenableVrmCommand)
       );
 
       Assert.That(gp.CurrentFunction, Is.EqualTo(GpFunction.Gpio));

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.cs
@@ -52,6 +52,27 @@ public partial class GpControllerTests {
     );
   }
 
+  private static Mcp2221AController CreateMcp2221AConfiguredAsAdc(
+    byte chipSettings3 = 0b_0_1_1_01_1_00 // VRM 1.024V (factory default)
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp1Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC1)
+    const byte InitialGp2Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC2)
+    const byte InitialGp3Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC3)
+
+    return Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings3: chipSettings3
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+  }
+
   private static IEnumerable<byte> YieldTestCases_GP0_InvalidConfigurationSettings()
   {
     yield return 0b_000_1_0_010; // LED_URX

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.IGpControllerGroup.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.IGpControllerGroup.cs
@@ -1836,4 +1836,181 @@ partial class Mcp2221AGpioDriverTests {
     Assert.That(mcp2221A.GpPin3.LastUpdatedValue, Is.EqualTo(initialGp3Value));
     Assert.That(mcp2221A.GpPin3.CurrentMode, Is.EqualTo(initialGp3Mode));
   }
+
+  [Test]
+  public void FetchAdcRawValuesAsync_Disposed()
+    => FetchAdcRawValuesSyncOrAsync_Disposed(
+      static async gpPins => await gpPins.FetchAdcRawValuesAsync().ConfigureAwait(false)
+    );
+
+  [Test]
+  public void FetchAdcRawValues_Disposed()
+    => FetchAdcRawValuesSyncOrAsync_Disposed(
+      static gpPins => {
+        gpPins.FetchAdcRawValues();
+        return default;
+      }
+    );
+
+  private void FetchAdcRawValuesSyncOrAsync_Disposed(
+    Func<IGpControllerGroup, ValueTask> fetchAdcRawValuesAsyncFunc
+  )
+  {
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    mcp2221A.Dispose();
+
+    Assert.That(
+      async () => await fetchAdcRawValuesAsyncFunc(mcp2221A.GpPins),
+      Throws.TypeOf<ObjectDisposedException>()
+    );
+  }
+
+  [Test]
+  public void FetchAdcRawValuesAsync_CancellationRequested()
+    => FetchAdcRawValuesSyncOrAsync_CancellationRequested(
+      static async (gpPins, ct) => await gpPins.FetchAdcRawValuesAsync(ct).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void FetchAdcRawValues_CancellationRequested()
+    => FetchAdcRawValuesSyncOrAsync_CancellationRequested(
+      static (gpPins, ct) => {
+        gpPins.FetchAdcRawValues(ct);
+        return default;
+      }
+    );
+
+  private void FetchAdcRawValuesSyncOrAsync_CancellationRequested(
+    Func<IGpControllerGroup, CancellationToken, ValueTask> fetchAdcRawValuesAsyncFunc
+  )
+  {
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true
+    );
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    // command should not be sent
+    // Mcp2221AControllerTests.AppendPseudoResponse(...);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    Assert.That(
+      async () => await fetchAdcRawValuesAsyncFunc(mcp2221A.GpPins, cts.Token),
+      Throws
+        .TypeOf<OperationCanceledException>()
+        .With
+        .Property(nameof(OperationCanceledException.CancellationToken))
+        .EqualTo(cts.Token)
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+      Is.Zero,
+      "command should not be sent"
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_FetchAdcRawValuesSyncOrAsync()
+  {
+    yield return new object[] { "00-00-", "00-00-", "00-00-", new AdcAllChannelSample((ushort)0x_00_00u, (ushort)0x_00_00u, (ushort)0x_00_00u) };
+    yield return new object[] { "FF-00-", "00-00-", "00-00-", new AdcAllChannelSample((ushort)0x_00_FFu, (ushort)0x_00_00u, (ushort)0x_00_00u) };
+    yield return new object[] { "00-03-", "00-00-", "00-00-", new AdcAllChannelSample((ushort)0x_03_00u, (ushort)0x_00_00u, (ushort)0x_00_00u) };
+    yield return new object[] { "00-00-", "FF-00-", "00-00-", new AdcAllChannelSample((ushort)0x_00_00u, (ushort)0x_00_FFu, (ushort)0x_00_00u) };
+    yield return new object[] { "00-00-", "00-03-", "00-00-", new AdcAllChannelSample((ushort)0x_00_00u, (ushort)0x_03_00u, (ushort)0x_00_00u) };
+    yield return new object[] { "00-00-", "00-00-", "FF-00-", new AdcAllChannelSample((ushort)0x_00_00u, (ushort)0x_00_00u, (ushort)0x_00_FFu) };
+    yield return new object[] { "00-00-", "00-00-", "00-03-", new AdcAllChannelSample((ushort)0x_00_00u, (ushort)0x_00_00u, (ushort)0x_03_00u) };
+    yield return new object[] { "FF-03-", "FF-03-", "FF-03-", new AdcAllChannelSample((ushort)0x_03_FFu, (ushort)0x_03_FFu, (ushort)0x_03_FFu) };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_FetchAdcRawValuesSyncOrAsync))]
+  public void FetchAdcRawValuesAsync(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    AdcAllChannelSample expectedAdcRawValues
+  )
+    => FetchAdcRawValuesSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdcRawValues: expectedAdcRawValues,
+      static async gpPins => await gpPins.FetchAdcRawValuesAsync().ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_FetchAdcRawValuesSyncOrAsync))]
+  public void FetchAdcRawValues(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    AdcAllChannelSample expectedAdcRawValues
+  )
+    => FetchAdcRawValuesSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdcRawValues: expectedAdcRawValues,
+      static gpPins => new(gpPins.FetchAdcRawValues())
+    );
+
+  private void FetchAdcRawValuesSyncOrAsync(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    AdcAllChannelSample expectedAdcRawValues,
+    Func<IGpControllerGroup, ValueTask<AdcAllChannelSample>> fetchAdcRawValuesAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp1Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC1)
+    const byte InitialGp2Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC2)
+    const byte InitialGp3Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC3)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    // [MCP2221A] 3.1.1 STATUS/SET PARAMETERS
+    var statusSetParametersResponse = string.Concat(
+      "10-00-",
+      string.Join("-", Enumerable.Repeat("00", 50 - 2)), "-",
+      // [50-55] ADC Data (16-bit) values
+      adcChannel0Response, // [50] LSB [51] MSB of ADC CH0
+      adcChannel1Response, // [52] LSB [53] MSB of ADC CH1
+      adcChannel2Response, // [54] LSB [55] MSB of ADC CH2
+      string.Join("-", Enumerable.Repeat("00", 64 - 56))
+    );
+
+    Mcp2221AControllerTests.AppendPseudoResponse(mcp2221A, statusSetParametersResponse);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    var expectedSentCommand = new byte[64]; // [1-64]: don't care
+
+    expectedSentCommand[0] = 0x10; // STATUS/SET PARAMETERS
+
+    AdcAllChannelSample adcRawValues = default;
+
+    Assert.That(
+      async () => adcRawValues = await fetchAdcRawValuesAsyncFunc(mcp2221A.GpPins),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A),
+      SequenceIs.EqualTo(expectedSentCommand)
+    );
+
+    Assert.That(adcRawValues, Is.EqualTo(expectedAdcRawValues));
+  }
 }

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/IGpControllerGroupExtensions.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/IGpControllerGroupExtensions.cs
@@ -2926,4 +2926,587 @@ public class IGpControllerGroupExtensionsTests {
     Assert.That(mcp2221A.GpPin2.CurrentMode, Is.EqualTo(PinMode.Input));
     Assert.That(mcp2221A.GpPin3.CurrentMode, Is.EqualTo(PinMode.Output));
   }
+
+  [Test]
+  public void ReadAnalogRawAsync_ArgumentNull()
+  {
+    IGpControllerGroup? gpPins = null;
+
+    Assert.That(
+      () => gpPins!.ReadAnalogRawAsync(),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("gpPins")
+    );
+  }
+
+  [Test]
+  public void ReadAnalogRaw_ArgumentNull()
+  {
+    IGpControllerGroup? gpPins = null;
+
+    Assert.That(
+      () => _ = gpPins!.ReadAnalogRaw(),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("gpPins")
+    );
+  }
+
+  [Test]
+  public void ReadAnalogRawAsync_CancellationRequested()
+    => ReadAnalogRawSyncOrAsync_CancellationRequested(
+      static async (gpPins, ct) => _ = await gpPins.ReadAnalogRawAsync(ct).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void ReadAnalogRaw_CancellationRequested()
+    => ReadAnalogRawSyncOrAsync_CancellationRequested(
+      static (gpPins, ct) => {
+        _ = gpPins.ReadAnalogRaw(ct);
+        return default;
+      }
+    );
+
+  private void ReadAnalogRawSyncOrAsync_CancellationRequested(
+    Func<IGpControllerGroup, CancellationToken, ValueTask> readAnalogRawAsyncFunc
+  )
+  {
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true
+    );
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    // command should not be sent
+    // Mcp2221AControllerTests.AppendPseudoResponse(...);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    Assert.That(
+      async () => await readAnalogRawAsyncFunc(mcp2221A.GpPins, cts.Token),
+      Throws
+        .TypeOf<OperationCanceledException>()
+        .With
+        .Property(nameof(OperationCanceledException.CancellationToken))
+        .EqualTo(cts.Token)
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+      Is.Zero,
+      "command should not be sent"
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_ReadAnalogRawSyncOrAsync()
+  {
+    yield return new object[] { "00-00-", "00-00-", "00-00-", 0x_00_00, 0x_00_00, 0x_00_00 };
+    yield return new object[] { "FF-00-", "00-00-", "00-00-", 0x_00_FF, 0x_00_00, 0x_00_00 };
+    yield return new object[] { "00-03-", "00-00-", "00-00-", 0x_03_00, 0x_00_00, 0x_00_00 };
+    yield return new object[] { "00-00-", "FF-00-", "00-00-", 0x_00_00, 0x_00_FF, 0x_00_00 };
+    yield return new object[] { "00-00-", "00-03-", "00-00-", 0x_00_00, 0x_03_00, 0x_00_00 };
+    yield return new object[] { "00-00-", "00-00-", "FF-00-", 0x_00_00, 0x_00_00, 0x_00_FF };
+    yield return new object[] { "00-00-", "00-00-", "00-03-", 0x_00_00, 0x_00_00, 0x_03_00 };
+    yield return new object[] { "FF-03-", "FF-03-", "FF-03-", 0x_03_FF, 0x_03_FF, 0x_03_FF };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncOrAsync))]
+  public void ReadAnalogRawAsync(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue
+  )
+    => ReadAnalogRawSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdc1RawValue: expectedAdc1RawValue,
+      expectedAdc2RawValue: expectedAdc2RawValue,
+      expectedAdc3RawValue: expectedAdc3RawValue,
+      static async gpPins => await gpPins.ReadAnalogRawAsync().ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogRawSyncOrAsync))]
+  public void ReadAnalogRaw(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue
+  )
+    => ReadAnalogRawSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      expectedAdc1RawValue: expectedAdc1RawValue,
+      expectedAdc2RawValue: expectedAdc2RawValue,
+      expectedAdc3RawValue: expectedAdc3RawValue,
+      static gpPins => new(gpPins.ReadAnalogRaw())
+    );
+
+  private void ReadAnalogRawSyncOrAsync(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    int expectedAdc1RawValue,
+    int expectedAdc2RawValue,
+    int expectedAdc3RawValue,
+    Func<IGpControllerGroup, ValueTask<(int, int, int)>> readAnalogRawAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp1Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC1)
+    const byte InitialGp2Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC2)
+    const byte InitialGp3Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC3)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    // [MCP2221A] 3.1.1 STATUS/SET PARAMETERS
+    var statusSetParametersResponse = string.Concat(
+      "10-00-",
+      string.Join("-", Enumerable.Repeat("00", 50 - 2)), "-",
+      // [50-55] ADC Data (16-bit) values
+      adcChannel0Response, // [50] LSB [51] MSB of ADC CH0
+      adcChannel1Response, // [52] LSB [53] MSB of ADC CH1
+      adcChannel2Response, // [54] LSB [55] MSB of ADC CH2
+      string.Join("-", Enumerable.Repeat("00", 64 - 56))
+    );
+
+    Mcp2221AControllerTests.AppendPseudoResponse(mcp2221A, statusSetParametersResponse);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    var expectedSentCommand = new byte[64]; // [1-64]: don't care
+
+    expectedSentCommand[0] = 0x10; // STATUS/SET PARAMETERS
+
+    (int, int, int) adcRawValues = default;
+
+    Assert.That(
+      async () => adcRawValues = await readAnalogRawAsyncFunc(mcp2221A.GpPins),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A),
+      SequenceIs.EqualTo(expectedSentCommand)
+    );
+
+    var (adc1RawValue, adc2RawValue, adc3RawValue) = adcRawValues;
+
+    Assert.That(adc1RawValue, Is.EqualTo(expectedAdc1RawValue));
+    Assert.That(adc2RawValue, Is.EqualTo(expectedAdc2RawValue));
+    Assert.That(adc3RawValue, Is.EqualTo(expectedAdc3RawValue));
+  }
+
+  [Test]
+  public void ReadAnalogVoltageAsync_ArgumentNull()
+  {
+    IGpControllerGroup? gpPins = null;
+
+    Assert.That(
+      () => gpPins!.ReadAnalogVoltageAsync(),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("gpPins")
+    );
+  }
+
+  [Test]
+  public void ReadAnalogVoltage_ArgumentNull()
+  {
+    IGpControllerGroup? gpPins = null;
+
+    Assert.That(
+      () => _ = gpPins!.ReadAnalogVoltage(),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("gpPins")
+    );
+  }
+
+  [Test]
+  public void ReadAnalogVoltageAsync_CancellationRequested()
+    => ReadAnalogVoltageSyncOrAsync_CancellationRequested(
+      static async (gpPins, ct) => _ = await gpPins.ReadAnalogVoltageAsync(ct).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void ReadAnalogVoltage_CancellationRequested()
+    => ReadAnalogVoltageSyncOrAsync_CancellationRequested(
+      static (gpPins, ct) => {
+        _ = gpPins.ReadAnalogVoltage(ct);
+        return default;
+      }
+    );
+
+  private void ReadAnalogVoltageSyncOrAsync_CancellationRequested(
+    Func<IGpControllerGroup, CancellationToken, ValueTask> readAnalogVoltageAsyncFunc
+  )
+  {
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true
+    );
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    // command should not be sent
+    // Mcp2221AControllerTests.AppendPseudoResponse(...);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    Assert.That(
+      async () => await readAnalogVoltageAsyncFunc(mcp2221A.GpPins, cts.Token),
+      Throws
+        .TypeOf<OperationCanceledException>()
+        .With
+        .Property(nameof(OperationCanceledException.CancellationToken))
+        .EqualTo(cts.Token)
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+      Is.Zero,
+      "command should not be sent"
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_ReadAnalogVoltageSyncOrAsync()
+  {
+    const byte InitialChipSettings3_AdcVrm1024 = 0b_0_1_1_01_1_00; // ADC: VRM 1.024V (factory default)
+    const byte InitialChipSettings3_AdcVrm2048 = 0b_0_1_1_10_1_00; // ADC: VRM 2.048V
+    const byte InitialChipSettings3_AdcVrm4096 = 0b_0_1_1_11_1_00; // ADC: VRM 4.096V
+    const byte InitialChipSettings3_AdcVrmOff = 0b_0_1_1_00_1_00; // ADC: VRM Off
+
+    yield return new object[] { "00-00-", "01-00-", "FF-03-", InitialChipSettings3_AdcVrm1024, 0.0d, 0.001d, 1.023d };
+    yield return new object[] { "01-00-", "FF-03-", "00-00-", InitialChipSettings3_AdcVrm2048, 0.002d, 2.046d, 0.0d };
+    yield return new object[] { "FF-03-", "00-00-", "01-00-", InitialChipSettings3_AdcVrm4096, 4.092d, 0.0d, 0.004d };
+
+    yield return new object[] { "00-00-", "00-00-", "00-00-", InitialChipSettings3_AdcVrmOff, 0.0d, 0.0d, 0.0d };
+    yield return new object[] { "01-00-", "01-00-", "01-00-", InitialChipSettings3_AdcVrmOff, 0.0d, 0.0d, 0.0d };
+    yield return new object[] { "FF-03-", "FF-03-", "FF-03-", InitialChipSettings3_AdcVrmOff, 0.0d, 0.0d, 0.0d };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogVoltageSyncOrAsync))]
+  public void ReadAnalogVoltageAsync(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    byte initialChipSettings3,
+    double expectedAdc1Voltage,
+    double expectedAdc2Voltage,
+    double expectedAdc3Voltage
+  )
+    => ReadAnalogVoltageSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      initialChipSettings3: initialChipSettings3,
+      expectedAdc1Voltage: expectedAdc1Voltage,
+      expectedAdc2Voltage: expectedAdc2Voltage,
+      expectedAdc3Voltage: expectedAdc3Voltage,
+      static async gpPins => await gpPins.ReadAnalogVoltageAsync().ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogVoltageSyncOrAsync))]
+  public void ReadAnalogVoltage(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    byte initialChipSettings3,
+    double expectedAdc1Voltage,
+    double expectedAdc2Voltage,
+    double expectedAdc3Voltage
+  )
+    => ReadAnalogVoltageSyncOrAsync(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      initialChipSettings3: initialChipSettings3,
+      expectedAdc1Voltage: expectedAdc1Voltage,
+      expectedAdc2Voltage: expectedAdc2Voltage,
+      expectedAdc3Voltage: expectedAdc3Voltage,
+      static gpPins => new(gpPins.ReadAnalogVoltage())
+    );
+
+  private void ReadAnalogVoltageSyncOrAsync(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    byte initialChipSettings3,
+    double expectedAdc1Voltage,
+    double expectedAdc2Voltage,
+    double expectedAdc3Voltage,
+    Func<IGpControllerGroup, ValueTask<(double, double, double)>> readAnalogVoltageAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp1Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC1)
+    const byte InitialGp2Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC2)
+    const byte InitialGp3Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC3)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings3: initialChipSettings3
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    // [MCP2221A] 3.1.1 STATUS/SET PARAMETERS
+    var statusSetParametersResponse = string.Concat(
+      "10-00-",
+      string.Join("-", Enumerable.Repeat("00", 50 - 2)), "-",
+      // [50-55] ADC Data (16-bit) values
+      adcChannel0Response, // [50] LSB [51] MSB of ADC CH0
+      adcChannel1Response, // [52] LSB [53] MSB of ADC CH1
+      adcChannel2Response, // [54] LSB [55] MSB of ADC CH2
+      string.Join("-", Enumerable.Repeat("00", 64 - 56))
+    );
+
+    Mcp2221AControllerTests.AppendPseudoResponse(mcp2221A, statusSetParametersResponse);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    var expectedSentCommand = new byte[64]; // [1-64]: don't care
+
+    expectedSentCommand[0] = 0x10; // STATUS/SET PARAMETERS
+
+    (double, double, double) adcVoltages = default;
+
+    Assert.That(
+      async () => adcVoltages = await readAnalogVoltageAsyncFunc(mcp2221A.GpPins),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A),
+      SequenceIs.EqualTo(expectedSentCommand)
+    );
+
+    var (adc1Voltage, adc2Voltage, adc3Voltage) = adcVoltages;
+
+    Assert.That(adc1Voltage, Is.EqualTo(expectedAdc1Voltage).Within(1e-9));
+    Assert.That(adc2Voltage, Is.EqualTo(expectedAdc2Voltage).Within(1e-9));
+    Assert.That(adc3Voltage, Is.EqualTo(expectedAdc3Voltage).Within(1e-9));
+  }
+
+  [Test]
+  public void ReadAnalogVoltageAsync_WithReferenceVoltage_ArgumentNull()
+  {
+    IGpControllerGroup? gpPins = null;
+
+    Assert.That(
+      () => gpPins!.ReadAnalogVoltageAsync(referenceVoltage: 5.0),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("gpPins")
+    );
+  }
+
+  [Test]
+  public void ReadAnalogVoltage_WithReferenceVoltage_ArgumentNull()
+  {
+    IGpControllerGroup? gpPins = null;
+
+    Assert.That(
+      () => _ = gpPins!.ReadAnalogVoltage(referenceVoltage: 5.0),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("gpPins")
+    );
+  }
+
+  [Test]
+  public void ReadAnalogVoltageAsync_WithReferenceVoltage_CancellationRequested()
+    => ReadAnalogVoltageSyncOrAsync_WithReferenceVoltage_CancellationRequested(
+      static async (gpPins, ct) => _ = await gpPins.ReadAnalogVoltageAsync(referenceVoltage: 5.0, ct).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void ReadAnalogVoltage_WithReferenceVoltage_CancellationRequested()
+    => ReadAnalogVoltageSyncOrAsync_WithReferenceVoltage_CancellationRequested(
+      static (gpPins, ct) => {
+        _ = gpPins.ReadAnalogVoltage(referenceVoltage: 5.0, ct);
+        return default;
+      }
+    );
+
+  private void ReadAnalogVoltageSyncOrAsync_WithReferenceVoltage_CancellationRequested(
+    Func<IGpControllerGroup, CancellationToken, ValueTask> readAnalogVoltageAsyncFunc
+  )
+  {
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true
+    );
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    // command should not be sent
+    // Mcp2221AControllerTests.AppendPseudoResponse(...);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    Assert.That(
+      async () => await readAnalogVoltageAsyncFunc(mcp2221A.GpPins, cts.Token),
+      Throws
+        .TypeOf<OperationCanceledException>()
+        .With
+        .Property(nameof(OperationCanceledException.CancellationToken))
+        .EqualTo(cts.Token)
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+      Is.Zero,
+      "command should not be sent"
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_ReadAnalogVoltageSyncOrAsync_WithReferenceVoltage()
+  {
+    const double Vdd_5V0 = 5.0;
+    const double Vdd_3V3 = 3.3;
+    const double Vdd_Zero = 0.0;
+
+    yield return new object[] { "00-00-", "00-02-", "FF-03-", Vdd_5V0, 0.0d, 2.5d, (1023.0d * 5.0d) / 1024.0 };
+    yield return new object[] { "00-00-", "00-01-", "FF-03-", Vdd_3V3, 0.0d, 0.825d, (1023.0d * 3.3d) / 1024.0d };
+    yield return new object[] { "00-00-", "00-01-", "FF-03-", Vdd_Zero, 0.0d, 0.0d, 0.0d };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogVoltageSyncOrAsync_WithReferenceVoltage))]
+  public void ReadAnalogVoltageAsync_WithReferenceVoltage(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    double referenceVoltage,
+    double expectedAdc1Voltage,
+    double expectedAdc2Voltage,
+    double expectedAdc3Voltage
+  )
+    => ReadAnalogVoltageSyncOrAsync_WithReferenceVoltage(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      referenceVoltage: referenceVoltage,
+      expectedAdc1Voltage: expectedAdc1Voltage,
+      expectedAdc2Voltage: expectedAdc2Voltage,
+      expectedAdc3Voltage: expectedAdc3Voltage,
+      static async (gpPins, referenceVoltage) => await gpPins.ReadAnalogVoltageAsync(referenceVoltage).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ReadAnalogVoltageSyncOrAsync_WithReferenceVoltage))]
+  public void ReadAnalogVoltage_WithReferenceVoltage(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    double referenceVoltage,
+    double expectedAdc1Voltage,
+    double expectedAdc2Voltage,
+    double expectedAdc3Voltage
+  )
+    => ReadAnalogVoltageSyncOrAsync_WithReferenceVoltage(
+      adcChannel0Response: adcChannel0Response,
+      adcChannel1Response: adcChannel1Response,
+      adcChannel2Response: adcChannel2Response,
+      referenceVoltage: referenceVoltage,
+      expectedAdc1Voltage: expectedAdc1Voltage,
+      expectedAdc2Voltage: expectedAdc2Voltage,
+      expectedAdc3Voltage: expectedAdc3Voltage,
+      static (gpPins, referenceVoltage) => new(gpPins.ReadAnalogVoltage(referenceVoltage))
+    );
+
+  private void ReadAnalogVoltageSyncOrAsync_WithReferenceVoltage(
+    string adcChannel0Response,
+    string adcChannel1Response,
+    string adcChannel2Response,
+    double referenceVoltage,
+    double expectedAdc1Voltage,
+    double expectedAdc2Voltage,
+    double expectedAdc3Voltage,
+    Func<IGpControllerGroup, double, ValueTask<(double, double, double)>> readAnalogVoltageAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp1Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC1)
+    const byte InitialGp2Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC2)
+    const byte InitialGp3Settings = 0b_000_0_0_010; // Alternate Function 0 (ADC3)
+    const byte InitialChipSettings3 = 0b_0_1_1_00_0_00; // ADC: VDD
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings3: InitialChipSettings3
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    // [MCP2221A] 3.1.1 STATUS/SET PARAMETERS
+    var statusSetParametersResponse = string.Concat(
+      "10-00-",
+      string.Join("-", Enumerable.Repeat("00", 50 - 2)), "-",
+      // [50-55] ADC Data (16-bit) values
+      adcChannel0Response, // [50] LSB [51] MSB of ADC CH0
+      adcChannel1Response, // [52] LSB [53] MSB of ADC CH1
+      adcChannel2Response, // [54] LSB [55] MSB of ADC CH2
+      string.Join("-", Enumerable.Repeat("00", 64 - 56))
+    );
+
+    Mcp2221AControllerTests.AppendPseudoResponse(mcp2221A, statusSetParametersResponse);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    var expectedSentCommand = new byte[64]; // [1-64]: don't care
+
+    expectedSentCommand[0] = 0x10; // STATUS/SET PARAMETERS
+
+    (double, double, double) adcVoltages = default;
+
+    Assert.That(
+      async () => adcVoltages = await readAnalogVoltageAsyncFunc(mcp2221A.GpPins, referenceVoltage),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A),
+      SequenceIs.EqualTo(expectedSentCommand)
+    );
+
+    var (adc1Voltage, adc2Voltage, adc3Voltage) = adcVoltages;
+
+    Assert.That(adc1Voltage, Is.EqualTo(expectedAdc1Voltage).Within(1e-9));
+    Assert.That(adc2Voltage, Is.EqualTo(expectedAdc2Voltage).Within(1e-9));
+    Assert.That(adc3Voltage, Is.EqualTo(expectedAdc3Voltage).Within(1e-9));
+  }
 }

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221AController.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221AController.cs
@@ -41,7 +41,8 @@ public partial class Mcp2221AControllerTests {
     byte gp0Settings = 0b_000_1_0_010, // Output: HIGH, Alternate Function 0 (LED UART RX)
     byte gp1Settings = 0b_000_1_0_011, // Output: HIGH, Alternate Function 1 (LED UART TX)
     byte gp2Settings = 0b_000_1_0_001, // Output: HIGH, Dedicated function operation (USBCFG)
-    byte gp3Settings = 0b_000_1_0_001 // Output: HIGH, Dedicated function operation (LED I2C)
+    byte gp3Settings = 0b_000_1_0_001, // Output: HIGH, Dedicated function operation (LED I2C)
+    byte chipSettings3 = 0b_0_0_0_00_0_00 // INTDETFEEN(6): Disable, INTDETREEN(5): Disable, ADCVRM(4-3): VRM is off, ADCREF(2): VDD
   )
     => new(
       vendorId: vendorId,
@@ -171,7 +172,8 @@ public partial class Mcp2221AControllerTests {
           [
             ReportInput,
             0x61, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00,
+            0x00, 0x00, 0x00, chipSettings3,
             vendorIdHigh, vendorIdLow, productIdHigh, productIdLow,
             0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -223,7 +225,7 @@ public partial class Mcp2221AControllerTests {
       var sequenceBytes = ToByteArray(sequence);
 
       if (verifyCommandLength && sequenceBytes.Length != CommandLength)
-        throw new InvalidCastException($"response sequence must be {CommandLength}-byte length (length: {sequenceBytes.Length}, sequence: '{sequence}')");
+        throw new InvalidOperationException($"response sequence must be {CommandLength}-byte length (length: {sequenceBytes.Length}, sequence: '{sequence}')");
 
       endPoint.ReadStream.Write(
 #if SYSTEM_IO_STREAM_WRITE_READONLYSPAN_OF_BYTE
@@ -250,7 +252,7 @@ public partial class Mcp2221AControllerTests {
   internal static Stream GetEndPointWriteStream(Mcp2221AController mcp2221A)
     => (mcp2221A.HidDevice as PseudoUsbHidDevice)!.EndPoint!.WriteStream!;
 
-  internal static ReadOnlyMemory<byte> GetSentCommand(Mcp2221AController mcp2221A)
+  internal static ReadOnlyMemory<byte> GetSentCommand(Mcp2221AController mcp2221A, int commandNumber = 0)
   {
     var stream = GetEndPointWriteStream(mcp2221A);
 
@@ -259,7 +261,7 @@ public partial class Mcp2221AControllerTests {
 
     var buffer = new byte[ReportLength];
 
-    stream.Position = 0L;
+    stream.Position = commandNumber * ReportLength;
 
     stream.ReadExactly(buffer.AsSpan(0, ReportLength));
 
@@ -365,6 +367,7 @@ public partial class Mcp2221AControllerTests {
     Assert.That(() => _ = device.GpPin3, Throws.Nothing);
     Assert.That(() => _ = device.I2cBus, Throws.Nothing);
     Assert.That(() => _ = device.GpioController, Throws.Nothing);
+    Assert.That(() => _ = device.CurrentAdcReferenceSource, Throws.Nothing);
 
     var i2cBus = device.I2cBus;
     var gp0 = device.GpPin0;
@@ -390,6 +393,7 @@ public partial class Mcp2221AControllerTests {
     Assert.That(() => _ = device.GpPin3, Throws.TypeOf<ObjectDisposedException>());
     Assert.That(() => _ = device.I2cBus, Throws.TypeOf<ObjectDisposedException>());
     Assert.That(() => _ = device.GpioController, Throws.TypeOf<ObjectDisposedException>());
+    Assert.That(() => _ = device.CurrentAdcReferenceSource, Throws.TypeOf<ObjectDisposedException>());
 
     Assert.That(() => _ = device.HardwareRevision, Throws.Nothing);
     Assert.That(() => _ = device.FirmwareRevision, Throws.Nothing);
@@ -633,5 +637,31 @@ public partial class Mcp2221AControllerTests {
     Assert.That(mcp2221A.GpPin3, Is.TypeOf<Gp3Controller>());
     Assert.That(mcp2221A.GpPin3.Index, Is.EqualTo(3));
     Assert.That(mcp2221A.GpPin3.PinName, Is.EqualTo("GP3"));
+  }
+
+  [TestCase(0b_0_0_0_00_0_00, VoltageReferenceSource.Vdd)]
+  [TestCase(0b_0_0_0_00_1_00, VoltageReferenceSource.VrmOff)]
+  [TestCase(0b_0_0_0_01_1_00, VoltageReferenceSource.Vrm1024)]
+  [TestCase(0b_0_0_0_10_1_00, VoltageReferenceSource.Vrm2048)]
+  [TestCase(0b_0_0_0_11_1_00, VoltageReferenceSource.Vrm4096)] // INTDETFEEN: 0, INTDETREEN: 0
+  [TestCase(0b_0_0_1_01_1_00, VoltageReferenceSource.Vrm1024)] // INTDETFEEN: 0, INTDETREEN: 1
+  [TestCase(0b_0_1_0_01_1_00, VoltageReferenceSource.Vrm1024)] // INTDETFEEN: 1, INTDETREEN: 0
+  [TestCase(0b_0_1_1_01_1_00, VoltageReferenceSource.Vrm1024)] // INTDETFEEN: 1, INTDETREEN: 1 (factory default)
+  public void CurrentAdcReferenceSource(
+    byte chipSettings3AdcBits,
+    VoltageReferenceSource expected
+  )
+  {
+    using var mcp2221A = Mcp2221AController.Create(
+      CreatePseudoDevice(
+        chipSettings3: chipSettings3AdcBits
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    Assert.That(
+      mcp2221A.CurrentAdcReferenceSource,
+      Is.EqualTo(expected)
+    );
   }
 }

--- a/tests/Smdn.Devices.Mcp2221A/System.IO/StreamExtensions.cs
+++ b/tests/Smdn.Devices.Mcp2221A/System.IO/StreamExtensions.cs
@@ -17,17 +17,18 @@ internal static class StreamExtensions {
     var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
 
     try {
-      int readTotal = 0;
+      for (;;) {
+        if (destination.IsEmpty)
+          return;
 
-      while (readTotal < destination.Length) {
-        int n = stream.Read(buffer, 0, BufferSize);
+        int read = stream.Read(buffer, 0, Math.Min(destination.Length, BufferSize));
 
-        if (n == 0)
+        if (read == 0)
           throw new EndOfStreamException();
 
-        buffer.AsMemory(0, n).Span.CopyTo(destination.Slice(readTotal));
+        buffer.AsMemory(0, read).Span.CopyTo(destination);
 
-        readTotal += n;
+        destination = destination.Slice(read);
       }
     }
     finally {


### PR DESCRIPTION
### Description
This PR introduces support for ADC (Analog-to-Digital Converter) inputs for the MCP2221A.

The implementation focuses on providing both low-level raw values and high-level voltage conversion with a focus on API consistency and hardware accuracy.

#### Key Changes and Features
- **New `IAdcController` Interface**: Introduced a dedicated interface for per-pin ADC control, allowing configuration of the global voltage reference and individual raw value reading. It supports both synchronous and asynchronous operations with a built-in caching mechanism for the last read value.
- **Enhanced `IGpControllerGroup` Interface**: Added methods to fetch all ADC channels in a single command for improved communication efficiency. Extension methods for direct voltage acquisition were also implemented.
- **Introduction of `AdcAllChannelSample`**: Added a new readonly record struct to hold a snapshot of raw 10-bit ADC values from all channels. It ensures data consistency and provides methods for value conversion.
- **Voltage Conversion Logic**: Implemented `AsVoltage` methods to convert raw values into physical voltage values [V]. It supports both internal VRM sources and explicit reference voltage values like VDD.

### Fixes issue
This PR will close #3.