### PR TITLE
Update Smdn.IO.UsbHid.Providers.* to stable release

### DIFF
--- a/examples/Smdn.Devices.Mcp2221A/ADC_Read/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/ADC_Read/Program.csproj
@@ -14,17 +14,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/ADC_ReadVoltage/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/ADC_ReadVoltage/Program.csproj
@@ -14,17 +14,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/GPIO_Read/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/GPIO_Read/Program.csproj
@@ -16,17 +16,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/GPIO_ShiftRegister/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/GPIO_ShiftRegister/Program.csproj
@@ -15,17 +15,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/GettingStarted/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/GettingStarted/Program.csproj
@@ -16,7 +16,7 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- If you need to specify the version of HidSharp, explicitly describe the PackageReference. -->
     <!--
     <PackageReference Include="HidSharp" Version="2.6.4" />
@@ -26,12 +26,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/GpioController_ShiftRegister/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/GpioController_ShiftRegister/Program.csproj
@@ -16,17 +16,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/GpioController_TM1637/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/GpioController_TM1637/Program.csproj
@@ -16,17 +16,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/I2CAdapter_BME280/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/I2CAdapter_BME280/Program.csproj
@@ -16,17 +16,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/I2CAdapter_HT16K33_4Digit14SegmentDisplay/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/I2CAdapter_HT16K33_4Digit14SegmentDisplay/Program.csproj
@@ -17,17 +17,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/I2CAdapter_MCP23017/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/I2CAdapter_MCP23017/Program.csproj
@@ -16,17 +16,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/I2CAdapter_US2066_SO1602A/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/I2CAdapter_US2066_SO1602A/Program.csproj
@@ -15,17 +15,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/SelectDevice/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/SelectDevice/Program.csproj
@@ -16,7 +16,7 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- If you need to specify the version of HidSharp, explicitly describe the PackageReference. -->
     <!--
     <PackageReference Include="HidSharp" Version="2.6.4" />
@@ -26,12 +26,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/blink-csharp/blink.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/blink-csharp/blink.csproj
@@ -15,17 +15,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/blink-visualbasic/blink.vbproj
+++ b/examples/Smdn.Devices.Mcp2221A/blink-visualbasic/blink.vbproj
@@ -15,17 +15,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/i2cscanbus/i2cscanbus.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/i2cscanbus/i2cscanbus.csproj
@@ -16,17 +16,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 

--- a/examples/Smdn.Devices.Mcp2221A/logging/logging.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/logging/logging.csproj
@@ -16,17 +16,17 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
 
     <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0-preview4" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
     <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
 
     <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
     -->
 
     <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
     <!--
-    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-preview5" />
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
     -->
   </ItemGroup>
 


### PR DESCRIPTION
### Fixes issue
Closes #1.

### Description
Update the package reference `Smdn.IO.UsbHid.Providers.*` in each project within the example directory to the stable release version.

This PR also closes #1. The issue reported in #1 does not appear to occur in the latest version of the HidSharp backend.
As background, the `unsafe` code has been removed from the HidSharp backend, addressing a potential cause of system hangs.
Since this issue is unlikely to occur again, closing #1.

When using `Smdn.IO.UsbHid.Providers.HidSharp-1.0.0`, the following code, similar to the one in #1, works without any issues.

```cs
using System;
using System.Threading.Tasks;

using Microsoft.Extensions.DependencyInjection;

using Smdn.Devices.Mcp2221A;
using Smdn.Devices.Mcp2221A.Peripherals.I2c;
using Smdn.IO.UsbHid.DependencyInjection;

var services = new ServiceCollection();

services.AddHidSharpUsbHid();

using var serviceProvider = services.BuildServiceProvider();

await using var device = await Mcp2221AController.CreateAsync(serviceProvider);

var address = new I2cAddress(0x20); // MCP23017

await device.I2cBus.WriteAsync(address, 100, new byte[] { 0x00, 0xFF, 0xFF }); // IODIR

var buffer = new byte[2];

for (;;) {
  await device.I2cBus.ReadAsync(address, 100, buffer);

  Console.Clear();
  Console.WriteLine("{0:B8}{1:B8}", buffer[0], buffer[1]);
}
```

```
Runtime Environment:
 OS Name:     ubuntu
 OS Version:  24.04
 OS Platform: Linux
 RID:         ubuntu.24.04-x64
 Base Path:   /usr/lib/dotnet/sdk/10.0.105/
```
