### PR TITLE
Add DAC output implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See [Smdn.Devices.Mcp2221A examples](examples/Smdn.Devices.Mcp2221A/).
     - [x] GPIO read/write value
     - [x] GPIO get/set direction
   - [x] ADC inputs
-  - [ ] DAC outputs
+  - [x] DAC outputs
   - [ ] Clock output
   - [ ] Interrupt detection
   - [x] Other functionalities
@@ -55,7 +55,7 @@ See [Smdn.Devices.Mcp2221A examples](examples/Smdn.Devices.Mcp2221A/).
     - [ ] Chip settings
       - [ ] Pin options
       - [ ] Clock output
-      - [ ] DAC outputs
+      - [x] DAC outputs
       - [x] ADC inputs
       - [ ] Interrupt detection
   - [ ] Flash read/write

--- a/examples/Smdn.Devices.Mcp2221A/DAC_Write/Program.cs
+++ b/examples/Smdn.Devices.Mcp2221A/DAC_Write/Program.cs
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Threading;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Smdn.Devices.Mcp2221A;
+using Smdn.IO.UsbHid.DependencyInjection;
+
+var services = new ServiceCollection();
+
+services.AddHidSharpUsbHid();
+
+using var serviceProvider = services.BuildServiceProvider();
+
+using var device = Mcp2221AController.Create(serviceProvider);
+
+// Configure GP2 and GP3 as DAC output.
+device.GpPin2.ConfigureAsDac();
+
+// By specifying the VoltageReferenceSource, you can select and set
+// the reference voltage for the DAC module. The reference voltage
+// can be set to one of the following: VDD, 4.096 V, 2.048 V, 1.024 V,
+// or off (0 V).
+// Note that the reference voltage and the output value applies to
+// the entire MCP2221A DAC module, not to individual DAC pins.
+// Therefore, the following settings apply to both GP2 and GP3.
+device.GpPin3.ConfigureAsDac(VoltageReferenceSource.Vrm2048);
+
+// Get the current reference voltage setting.
+Console.WriteLine($"{nameof(device.CurrentDacReferenceSource)}: {device.CurrentDacReferenceSource}");
+
+// Write DAC 5-bit raw analog value (0-31).
+// Since the ConfigureAsDac() method specifies 2.048 V as the
+// reference voltage, approximately 2.048 V will be output
+// from the pin assigned to the DAC. Additionally, because
+// the DAC output voltage is shared between GP2 and GP3,
+// both pins are set to the same voltage.
+device.GpPin2.WriteAnalogRaw(31);
+
+// Get the last DAC output value set.
+Console.WriteLine($"{nameof(device.LastWriteAnalogRawValue)}: {device.LastWriteAnalogRawValue}");
+
+Thread.Sleep(1000);
+
+// Set the output values for all DAC output pins by specifying
+// the voltage value [V]. Since the DAC has a resolution of
+// 5 bits, the resulting voltage values may not be as accurate
+// as expected.
+device.GpPins.WriteAnalogVoltage(1.0); // 1.0 [V]

--- a/examples/Smdn.Devices.Mcp2221A/DAC_Write/Program.csproj
+++ b/examples/Smdn.Devices.Mcp2221A/DAC_Write/Program.csproj
@@ -1,0 +1,31 @@
+﻿<!--
+SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Smdn.Devices.Mcp2221A" Version="1.0.0-preview2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+
+    <!-- Add HidSharp (Apache License 2.0) as the USB HID backend provider. -->
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.HidSharp" Version="1.0.0" />
+    <!-- Alternatively, you can use the following backend providers by changing the package reference. -->
+
+    <!-- Add LibUsbDotNet version 2 (LGPL-3.0, stable release) as the USB HID backend provider. -->
+    <!--
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNet" Version="1.0.0" />
+    -->
+
+    <!-- Add LibUsbDotNet version 3 (LGPL-3.0, alpha release) as the USB HID backend provider. -->
+    <!--
+    <PackageReference Include="Smdn.IO.UsbHid.Providers.LibUsbDotNetV3" Version="1.0.0-rc.1.3-0-167" />
+    -->
+  </ItemGroup>
+
+</Project>

--- a/examples/Smdn.Devices.Mcp2221A/DAC_Write/README.md
+++ b/examples/Smdn.Devices.Mcp2221A/DAC_Write/README.md
@@ -1,0 +1,2 @@
+# `DAC_Write`
+This example shows how to write DAC output value to MCP2221/MCP2221A.

--- a/examples/examples.slnx
+++ b/examples/examples.slnx
@@ -10,6 +10,9 @@ SPDX-License-Identifier: MIT
   <Folder Name="/Smdn.Devices.Mcp2221A/ADC_ReadVoltage/">
     <Project Path="Smdn.Devices.Mcp2221A/ADC_ReadVoltage/Program.csproj" />
   </Folder>
+  <Folder Name="/Smdn.Devices.Mcp2221A/DAC_Write/">
+    <Project Path="Smdn.Devices.Mcp2221A/DAC_Write/Program.csproj" />
+  </Folder>
   <Folder Name="/Smdn.Devices.Mcp2221A/DependencyInjection_Logging/">
     <Project Path="Smdn.Devices.Mcp2221A/DependencyInjection_Logging/Program.csproj" />
   </Folder>

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/DacVoltageConverter.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/DacVoltageConverter.cs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+
+namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio;
+
+internal static class DacVoltageConverter {
+  /// <remarks>
+  /// <para>
+  /// If <paramref name="dacVoltageReference"/> is <see cref="VoltageReferenceSource.VrmOff"/>,
+  /// this method always returns <c>0</c>.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="InvalidOperationException">
+  /// Thrown when <paramref name="dacVoltageReference"/> is <see cref="VoltageReferenceSource.Vdd"/>.
+  /// </exception>
+  /// <exception cref="ArgumentException">
+  /// Thrown when <paramref name="dacVoltageReference"/> is an undefined or unsupported
+  /// <see cref="VoltageReferenceSource"/> value.
+  /// </exception>
+  internal static int ToOutputValue(double voltage, VoltageReferenceSource dacVoltageReference)
+    => dacVoltageReference switch {
+      VoltageReferenceSource.VrmOff => 0,
+      VoltageReferenceSource.Vrm1024 => ToOutputValue(voltage: voltage, referenceVoltage: 1.024),
+      VoltageReferenceSource.Vrm2048 => ToOutputValue(voltage: voltage, referenceVoltage: 2.048),
+      VoltageReferenceSource.Vrm4096 => ToOutputValue(voltage: voltage, referenceVoltage: 4.096),
+
+      VoltageReferenceSource.Vdd
+        => throw new InvalidOperationException(
+          $"{nameof(VoltageReferenceSource)}.{nameof(VoltageReferenceSource.Vdd)} is not supported in this method. Use a method that accepts a specific Vdd voltage value instead."
+        ),
+
+      var invalid
+        => throw new ArgumentException(
+          message: $"Undefined {nameof(VoltageReferenceSource)} value: {invalid}",
+          paramName: nameof(dacVoltageReference)
+        ),
+    };
+
+  /// <remarks>
+  /// <para>
+  /// This method calculates the 5-bit raw value (0-31) using the following formula,
+  /// rounding the result to the nearest integer (away from zero):
+  /// <c>
+  ///   OutputValue = <see cref="Math.Round(double, MidpointRounding)"/>(31 * <paramref name="voltage"/> / <paramref name="referenceVoltage"/>, <see cref="MidpointRounding.AwayFromZero"/>);
+  /// </c>
+  /// The resulting value is clamped to the range 0 to 31 and applied to the DAC module.
+  /// </para>
+  /// </remarks>
+  internal static int ToOutputValue(double voltage, double referenceVoltage)
+  {
+    if (double.IsNaN(voltage) || double.IsInfinity(voltage))
+      throw new ArgumentException(message: "DAC output voltage must be a finite number.", paramName: nameof(voltage));
+    if (double.IsNaN(referenceVoltage) || double.IsInfinity(referenceVoltage))
+      throw new ArgumentException(message: "Reference voltage must be a finite number.", paramName: nameof(referenceVoltage));
+
+    if (voltage < 0.0)
+      throw new ArgumentOutOfRangeException(message: "DAC output voltage cannot be negative.", actualValue: voltage, paramName: nameof(voltage));
+    if (referenceVoltage < 0.0)
+      throw new ArgumentOutOfRangeException(message: "Reference voltage cannot be negative.", actualValue: referenceVoltage, paramName: nameof(referenceVoltage));
+
+    if (referenceVoltage < voltage)
+      throw new ArgumentOutOfRangeException(message: $"DAC output voltage cannot exceed reference voltage ({referenceVoltage} V).", actualValue: voltage, paramName: nameof(voltage));
+
+    if (referenceVoltage == 0.0)
+      return 0;
+
+    const int MaxOutputValue = 31;
+
+    var rawValue = (int)Math.Round(MaxOutputValue * voltage / referenceVoltage, MidpointRounding.AwayFromZero);
+
+    return MaxOutputValue < rawValue
+      ? throw new ArgumentOutOfRangeException(nameof(voltage), voltage, $"DAC output voltage cannot exceed reference voltage ({referenceVoltage} V).")
+      : rawValue;
+  }
+}

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Gp2Controller.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Gp2Controller.cs
@@ -43,6 +43,14 @@ public sealed class Gp2Controller :
   };
 
   /// <inheritdoc/>
+  VoltageReferenceSource IDacController.CurrentDacReferenceSource
+    => GpioDriver.CurrentDacReferenceSource;
+
+  /// <inheritdoc/>
+  int IDacController.LastWriteAnalogRawValue
+    => GpioDriver.GetLastAppliedDacRawValue();
+
+  /// <inheritdoc/>
   VoltageReferenceSource IAdcController.CurrentAdcReferenceSource
     => GpioDriver.CurrentAdcReferenceSource;
 
@@ -65,18 +73,68 @@ public sealed class Gp2Controller :
     };
 
   /// <inheritdoc/>
-  public ValueTask ConfigureAsDacAsync(CancellationToken cancellationToken = default)
+  public ValueTask ConfigureAsDacAsync(
+    VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd,
+    int? initialOutputValue = null,
+    CancellationToken cancellationToken = default
+  )
     => ConfigureGpDesignationAsync(
       gpDesignation: GpDesignation.AlternateFunction1,
+      dacVoltageReferenceSource: voltageReferenceSource,
+      dacOutputValue: initialOutputValue.HasValue
+        ? Mcp2221AGpioDriver.ThrowIfDacOutputValueOutOfRange(initialOutputValue.Value, nameof(initialOutputValue))
+        : null,
+      adcVoltageReferenceSource: null,
       cancellationToken: cancellationToken
     );
 
   /// <inheritdoc/>
-  public void ConfigureAsDac(CancellationToken cancellationToken = default)
+  public void ConfigureAsDac(
+    VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd,
+    int? initialOutputValue = null,
+    CancellationToken cancellationToken = default
+  )
     => ConfigureGpDesignation(
       gpDesignation: GpDesignation.AlternateFunction1,
+      dacVoltageReferenceSource: voltageReferenceSource,
+      dacOutputValue: initialOutputValue.HasValue
+        ? Mcp2221AGpioDriver.ThrowIfDacOutputValueOutOfRange(initialOutputValue.Value, nameof(initialOutputValue))
+        : null,
+      adcVoltageReferenceSource: null,
       cancellationToken: cancellationToken
     );
+
+  /// <inheritdoc/>
+  public void WriteAnalogRaw(
+    int value,
+    CancellationToken cancellationToken = default
+  )
+  {
+    GpioDriver.Transceiver.ThrowIfDisposed();
+
+    ThrowIfInvalidConfiguration(GpFunction.Dac);
+
+    GpioDriver.ApplyDacRawValue(
+      Mcp2221AGpioDriver.ThrowIfDacOutputValueOutOfRange(value, nameof(value)),
+      cancellationToken
+    );
+  }
+
+  /// <inheritdoc/>
+  public ValueTask WriteAnalogRawAsync(
+    int value,
+    CancellationToken cancellationToken = default
+  )
+  {
+    GpioDriver.Transceiver.ThrowIfDisposed();
+
+    ThrowIfInvalidConfiguration(GpFunction.Dac);
+
+    return GpioDriver.ApplyDacRawValueAsync(
+      value: Mcp2221AGpioDriver.ThrowIfDacOutputValueOutOfRange(value, nameof(value)),
+      cancellationToken
+    );
+  }
 
   /// <inheritdoc/>
   public ValueTask ConfigureAsAdcAsync(

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Gp3Controller.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Gp3Controller.cs
@@ -43,6 +43,14 @@ public sealed class Gp3Controller :
   };
 
   /// <inheritdoc/>
+  VoltageReferenceSource IDacController.CurrentDacReferenceSource
+    => GpioDriver.CurrentDacReferenceSource;
+
+  /// <inheritdoc/>
+  int IDacController.LastWriteAnalogRawValue
+    => GpioDriver.GetLastAppliedDacRawValue();
+
+  /// <inheritdoc/>
   VoltageReferenceSource IAdcController.CurrentAdcReferenceSource
     => GpioDriver.CurrentAdcReferenceSource;
 
@@ -65,18 +73,68 @@ public sealed class Gp3Controller :
     };
 
   /// <inheritdoc/>
-  public ValueTask ConfigureAsDacAsync(CancellationToken cancellationToken = default)
+  public ValueTask ConfigureAsDacAsync(
+    VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd,
+    int? initialOutputValue = null,
+    CancellationToken cancellationToken = default
+  )
     => ConfigureGpDesignationAsync(
       gpDesignation: GpDesignation.AlternateFunction1,
+      dacVoltageReferenceSource: voltageReferenceSource,
+      dacOutputValue: initialOutputValue.HasValue
+        ? Mcp2221AGpioDriver.ThrowIfDacOutputValueOutOfRange(initialOutputValue.Value, nameof(initialOutputValue))
+        : null,
+      adcVoltageReferenceSource: null,
       cancellationToken: cancellationToken
     );
 
   /// <inheritdoc/>
-  public void ConfigureAsDac(CancellationToken cancellationToken = default)
+  public void ConfigureAsDac(
+    VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd,
+    int? initialOutputValue = null,
+    CancellationToken cancellationToken = default
+  )
     => ConfigureGpDesignation(
       gpDesignation: GpDesignation.AlternateFunction1,
+      dacVoltageReferenceSource: voltageReferenceSource,
+      dacOutputValue: initialOutputValue.HasValue
+        ? Mcp2221AGpioDriver.ThrowIfDacOutputValueOutOfRange(initialOutputValue.Value, nameof(initialOutputValue))
+        : null,
+      adcVoltageReferenceSource: null,
       cancellationToken: cancellationToken
     );
+
+  /// <inheritdoc/>
+  public void WriteAnalogRaw(
+    int value,
+    CancellationToken cancellationToken = default
+  )
+  {
+    GpioDriver.Transceiver.ThrowIfDisposed();
+
+    ThrowIfInvalidConfiguration(GpFunction.Dac);
+
+    GpioDriver.ApplyDacRawValue(
+      Mcp2221AGpioDriver.ThrowIfDacOutputValueOutOfRange(value, nameof(value)),
+      cancellationToken
+    );
+  }
+
+  /// <inheritdoc/>
+  public ValueTask WriteAnalogRawAsync(
+    int value,
+    CancellationToken cancellationToken = default
+  )
+  {
+    GpioDriver.Transceiver.ThrowIfDisposed();
+
+    ThrowIfInvalidConfiguration(GpFunction.Dac);
+
+    return GpioDriver.ApplyDacRawValueAsync(
+      value: Mcp2221AGpioDriver.ThrowIfDacOutputValueOutOfRange(value, nameof(value)),
+      cancellationToken
+    );
+  }
 
   /// <inheritdoc/>
   public ValueTask ConfigureAsAdcAsync(

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/IDacController.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/IDacController.cs
@@ -6,19 +6,45 @@ using System.Threading.Tasks;
 
 namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio;
 
-internal interface IDacController {
-  /// <param name="cancellationToken">
-  /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
-  /// The default value is <see cref="CancellationToken.None"/>.
-  /// </param>
-  /// /// <exception cref="InvalidOperationException">
-  /// Thrown when <see cref="GpController.IsUsedByGpioController"/> is <see langword="true"/>.
-  /// </exception>
-  /// <seealso cref="GpFunction.Dac"/>
-  ValueTask ConfigureAsDacAsync(
-    CancellationToken cancellationToken = default
-  );
+/// <summary>
+/// Defines an interface for controlling the Digital-to-Analog
+/// Converter (DAC) pins of the MCP2221/MCP2221A.
+/// </summary>
+public interface IDacController {
+  /// <summary>
+  /// Gets the current voltage reference source configured for the DAC module.
+  /// </summary>
+  /// <remarks>
+  /// This property represents the global configuration for the DAC module
+  /// of the MCP2221A. Changing the reference source on one GP pin will
+  /// affect all other GP pins configured as DAC outputs, but does not affect
+  /// the ADC module configuration.
+  /// </remarks>
+  VoltageReferenceSource CurrentDacReferenceSource { get; }
 
+  /// <summary>
+  /// Gets the 5-bit raw output value (0-31) that was last written to the
+  /// DAC module.
+  /// </summary>
+  /// <remarks>
+  /// This property represents the global configuration for the DAC module
+  /// of the MCP2221A. If no write operation has been performed yet, this
+  /// property returns the value currently held by the controller (e.g.,
+  /// the default value from Flash settings).
+  /// </remarks>
+  int LastWriteAnalogRawValue { get; }
+
+  /// <summary>
+  /// Configures the GP pin to function as an Digital-to-Analog Converter (DAC)
+  /// output and sets the voltage reference source for the DAC module.
+  /// </summary>
+  /// <param name="voltageReferenceSource">
+  /// The <see cref="VoltageReferenceSource"/> to be used for the DAC.
+  /// </param>
+  /// <param name="initialOutputValue">
+  /// The initial 5-bit raw analog value (0-31) to be set for the DAC output.
+  /// If <see langword="null"/>, the current DAC output value is maintained.
+  /// </param>
   /// <param name="cancellationToken">
   /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
   /// The default value is <see cref="CancellationToken.None"/>.
@@ -26,12 +52,78 @@ internal interface IDacController {
   /// <exception cref="InvalidOperationException">
   /// Thrown when <see cref="GpController.IsUsedByGpioController"/> is <see langword="true"/>.
   /// </exception>
+  /// <exception cref="ArgumentOutOfRangeException">
+  /// <paramref name="initialOutputValue"/> is negative, or greater than 31 (the maximum
+  /// value for a 5-bit DAC).
+  /// </exception>
+  /// <remarks>
+  /// <para>
+  /// Note that the <paramref name="voltageReferenceSource"/> is a global setting
+  /// for the entire DAC module. Updating this value through one GP pin will
+  /// simultaneously change the reference source for all other DAC-enabled pins.
+  /// </para>
+  /// <para>
+  /// Unlike ADC configuration, this method allows specifying an initial output
+  /// value to ensure a predictable voltage level immediately upon pin function
+  /// switching.
+  /// </para>
+  /// </remarks>
+  /// <seealso cref="CurrentDacReferenceSource"/>
   /// <seealso cref="GpFunction.Dac"/>
   void ConfigureAsDac(
+    VoltageReferenceSource voltageReferenceSource,
+    int? initialOutputValue = null,
     CancellationToken cancellationToken = default
   );
 
-#if __FUTURE_VERSION
-  int DacValue { set; }
-#endif
+  /// <summary>
+  /// Asynchronously configures the GP pin to function as an Digital-to-Analog
+  /// Converter (DAC) output and sets the voltage reference source for the
+  /// DAC module.
+  /// </summary>
+  /// <inheritdoc cref="ConfigureAsDac(VoltageReferenceSource, int?, CancellationToken)"/>
+  /// <returns>
+  /// A <see cref="ValueTask"/> representing the asynchronous operation.
+  /// </returns>
+  ValueTask ConfigureAsDacAsync(
+    VoltageReferenceSource voltageReferenceSource,
+    int? initialOutputValue = null,
+    CancellationToken cancellationToken = default
+  );
+
+  /// <summary>
+  /// Writes the 5-bit raw analog value (0-31) to the DAC module.
+  /// </summary>
+  /// <param name="value">
+  /// The 5-bit raw analog value (0-31) to be set for the DAC output.
+  /// </param>
+  /// <param name="cancellationToken">
+  /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
+  /// The default value is <see cref="CancellationToken.None"/>.
+  /// </param>
+  /// <exception cref="ArgumentOutOfRangeException">
+  /// <paramref name="value"/> is negative, or greater than 31 (the maximum
+  /// value for a 5-bit DAC).
+  /// </exception>
+  /// <remarks>
+  /// Note that the analog output value is a global setting for the DAC module.
+  /// Updating this value through one GP pin will simultaneously change
+  /// the output value for all other DAC-enabled pins.
+  /// </remarks>
+  void WriteAnalogRaw(
+    int value,
+    CancellationToken cancellationToken = default
+  );
+
+  /// <inheritdoc cref="WriteAnalogRaw(int, CancellationToken)"/>
+  /// <summary>
+  /// Asynchronously writes the 5-bit raw analog value (0-31) to the DAC module.
+  /// </summary>
+  /// <returns>
+  /// A <see cref="ValueTask"/> representing the asynchronous operation.
+  /// </returns>
+  ValueTask WriteAnalogRawAsync(
+    int value,
+    CancellationToken cancellationToken = default
+  );
 }

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/IGpControllerGroup.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/IGpControllerGroup.cs
@@ -63,6 +63,17 @@ public interface IGpControllerGroup : IReadOnlyList<GpController> {
   Gp3Controller Gp3 { get; }
 
   /// <summary>
+  /// Gets the current voltage reference source configured for the DAC module.
+  /// </summary>
+  /// <remarks>
+  /// This property represents the global configuration for the DAC module
+  /// of the MCP2221A. Changing the reference source on one GP pin will
+  /// affect all other GP pins configured as DAC outputs, but does not affect
+  /// the ADC module configuration.
+  /// </remarks>
+  VoltageReferenceSource CurrentDacReferenceSource { get; }
+
+  /// <summary>
   /// Gets the current voltage reference source configured for the ADC module.
   /// </summary>
   /// <remarks>
@@ -345,9 +356,49 @@ public interface IGpControllerGroup : IReadOnlyList<GpController> {
   );
 
   /// <summary>
-  /// Fetches the current 10-bit raw input values from all ADC channels
-  /// (ADC1, ADC2, and ADC3) by sending a command to the device and updates
+  /// Applies the 5-bit raw analog value (0-31) to the DAC module and updates
   /// the internal cache.
+  /// </summary>
+  /// <param name="value">
+  /// The 5-bit raw analog value (0-31) to be set for the DAC output.
+  /// </param>
+  /// <param name="cancellationToken">
+  /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
+  /// The default value is <see cref="CancellationToken.None"/>.
+  /// </param>
+  /// <exception cref="ArgumentOutOfRangeException">
+  /// <paramref name="value"/> is negative, or greater than 31 (the maximum
+  /// value for a 5-bit DAC).
+  /// </exception>
+  /// <exception cref="OperationCanceledException">
+  /// The operation was canceled.
+  /// </exception>
+  /// <remarks>
+  /// This method updates the output value of the DAC module globally.
+  /// All GP pins configured as DAC outputs will be affected simultaneously.
+  /// </remarks>
+  void ApplyDacRawValue(
+    int value,
+    CancellationToken cancellationToken = default
+  );
+
+  /// <summary>
+  /// Asynchronously applies the 5-bit raw analog value (0-31) to the DAC module
+  /// and updates the internal cache.
+  /// </summary>
+  /// <inheritdoc cref="ApplyDacRawValue(int, CancellationToken)"/>
+  /// <returns>
+  /// A <see cref="ValueTask"/> representing the asynchronous operation.
+  /// </returns>
+  ValueTask ApplyDacRawValueAsync(
+    int value,
+    CancellationToken cancellationToken = default
+  );
+
+  /// <summary>
+  /// Fetches the current 10-bit raw input values from all ADC channels
+  /// (ADC1, ADC2, and ADC3) from the ADC module by sending a command to the
+  /// device and updates the internal cache.
   /// </summary>
   /// <param name="cancellationToken">
   /// The <see cref="CancellationToken"/> to monitor for cancellation requests.

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.Analog.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.Analog.cs
@@ -10,7 +10,35 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio;
 #pragma warning disable IDE0040
 partial class Mcp2221AGpioDriver {
 #pragma warning restore IDE0040
+  /// <exception cref="ArgumentOutOfRangeException">
+  /// <paramref name="value"/> is negative, or greater than 31 (the maximum
+  /// value for a 5-bit DAC).
+  /// </exception>
+  internal static int ThrowIfDacOutputValueOutOfRange(int value, string paramName)
+  {
+    const int DacOutputValueMax = 0b11111;
+
+    if (value is < 0 or > DacOutputValueMax) {
+      throw new ArgumentOutOfRangeException(
+        message: $"The DAC output value must be in range of 0 to {DacOutputValueMax} (5-bit).",
+        actualValue: value,
+        paramName: paramName
+      );
+    }
+
+    return value;
+  }
+
+  private int? lastAppliedDacRawValue;
   private AdcAllChannelSample lastFetchedAdcSample;
+
+  /// <inheritdoc/>
+  public VoltageReferenceSource CurrentDacReferenceSource
+    => (VoltageReferenceSource)(sramSettings.ReadDacVoltageReferenceByte() & 0b_0_0000_11_1);
+
+  /// <inheritdoc/>
+  public VoltageReferenceSource CurrentAdcReferenceSource
+    => (VoltageReferenceSource)(sramSettings.ReadAdcVoltageReferenceByte() & 0b_0_0000_11_1);
 
   private static class GetAdcChannelValuesCommand {
 #pragma warning disable IDE0060, SA1313
@@ -45,9 +73,61 @@ partial class Mcp2221AGpioDriver {
     }
   }
 
+  public int GetLastAppliedDacRawValue()
+  {
+    // If a value has been set most recently, return that value;
+    // otherwise, return the SRAM power-up DAC value.
+    if (lastAppliedDacRawValue.HasValue)
+      return lastAppliedDacRawValue.Value;
+    else
+      return sramSettings.ReadDacOutputValueByte() & 0b_0_00_11111;
+  }
+
   /// <inheritdoc/>
-  public VoltageReferenceSource CurrentAdcReferenceSource
-    => (VoltageReferenceSource)(sramSettings.ReadAdcVoltageReferenceByte() & 0b_0_0000_11_1);
+  public void ApplyDacRawValue(
+    int value,
+    CancellationToken cancellationToken = default
+  )
+  {
+    try {
+      SetGpSettings(
+        sramSettings: sramSettings.ModifyDacSettings(
+          dacVoltageReferenceSource: null,
+          dacOutputValue: ThrowIfDacOutputValueOutOfRange(value, nameof(value))
+        ),
+        cancellationToken: cancellationToken
+      );
+
+      lastAppliedDacRawValue = value;
+    }
+    catch {
+      sramSettings.Restore();
+      throw;
+    }
+  }
+
+  /// <inheritdoc/>
+  public async ValueTask ApplyDacRawValueAsync(
+    int value,
+    CancellationToken cancellationToken = default
+  )
+  {
+    try {
+      await SetGpSettingsAsync(
+        sramSettings: sramSettings.ModifyDacSettings(
+          dacVoltageReferenceSource: null,
+          dacOutputValue: ThrowIfDacOutputValueOutOfRange(value, nameof(value))
+        ),
+        cancellationToken: cancellationToken
+      ).ConfigureAwait(false);
+
+      lastAppliedDacRawValue = value;
+    }
+    catch {
+      sramSettings.Restore();
+      throw;
+    }
+  }
 
   /// <summary>
   /// Returns the cached 10-bit raw ADC input value (0-1023) for the specified GP pin

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/IGpControllerGroupExtensions.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/IGpControllerGroupExtensions.cs
@@ -908,5 +908,173 @@ public static class IGpControllerGroupExtensions {
         ).ConfigureAwait(false)
       ).AsVoltage(referenceVoltage);
     }
+
+    /// <summary>
+    /// Sets the DAC output to the specified voltage [V] based on the currently
+    /// configured voltage reference source (VRM).
+    /// </summary>
+    /// <param name="voltage">
+    /// The target voltage [V] to be output from the GP pins assigned to DAC output.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
+    /// The default value is <see cref="CancellationToken.None"/>.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="voltage"/> is negative, or the converted DAC output
+    /// value is out of range (exceeds the reference voltage specified by
+    /// <see cref="IGpControllerGroup.CurrentDacReferenceSource"/>).
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="voltage"/> is <see cref="double.NaN"/>,
+    /// <see cref="double.PositiveInfinity"/> or <see cref="double.NegativeInfinity"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="IGpControllerGroup.CurrentDacReferenceSource"/> is
+    /// <see cref="VoltageReferenceSource.Vdd"/>, because the Vdd voltage value
+    /// required for calculation is not provided in this overload.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This method calculates the nearest 5-bit raw value (0-31) based on the
+    /// current <see cref="IGpControllerGroup.CurrentDacReferenceSource"/> and applies
+    /// it to the DAC module.
+    /// </para>
+    /// <para>
+    /// If <see cref="IGpControllerGroup.CurrentDacReferenceSource"/> is
+    /// <see cref="VoltageReferenceSource.VrmOff"/>, this method always sets <c>0</c> for
+    /// the DAC output regardless of the value of <paramref name="voltage"/>.
+    /// </para>
+    /// <para>
+    /// Note that this method does not account for cases where the actual VDD supplied
+    /// to the MCP2221A is lower than the reference voltage specified by
+    /// <see cref="IGpControllerGroup.CurrentDacReferenceSource"/>.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="WriteAnalogVoltage(IGpControllerGroup, double, double, CancellationToken)"/>
+    /// <seealso cref="IGpControllerGroup.ApplyDacRawValue"/>
+    public void WriteAnalogVoltage(
+      double voltage,
+      CancellationToken cancellationToken = default
+    )
+    {
+      ThrowIfThisArgumentIsNull(gpPins, nameof(gpPins));
+
+      gpPins.ApplyDacRawValue(
+        value: DacVoltageConverter.ToOutputValue(
+          voltage: voltage,
+          dacVoltageReference: gpPins.CurrentDacReferenceSource
+        ),
+        cancellationToken: cancellationToken
+      );
+    }
+
+    /// <summary>
+    /// Asynchronously sets the DAC output to the specified voltage [V]
+    /// based on the currently configured voltage reference source (VRM).
+    /// </summary>
+    /// <inheritdoc cref="WriteAnalogVoltage(IGpControllerGroup, double, CancellationToken)"/>
+    public ValueTask WriteAnalogVoltageAsync(
+      double voltage,
+      CancellationToken cancellationToken = default
+    )
+    {
+      ThrowIfThisArgumentIsNull(gpPins, nameof(gpPins));
+
+      return gpPins.ApplyDacRawValueAsync(
+        value: DacVoltageConverter.ToOutputValue(
+          voltage: voltage,
+          dacVoltageReference: gpPins.CurrentDacReferenceSource
+        ),
+        cancellationToken: cancellationToken
+      );
+    }
+
+    /// <summary>
+    /// Sets the DAC output to the specified voltage [V] based on the specified
+    /// reference voltage value.
+    /// </summary>
+    /// <param name="voltage">
+    /// The target voltage [V] to be output from the GP pins assigned to DAC output.
+    /// </param>
+    /// <param name="referenceVoltage">
+    /// The reference voltage [V] used for calculation (e.g., the measured VDD voltage
+    /// or a specific internal reference voltage).
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The <see cref="CancellationToken"/> to monitor for cancellation requests.
+    /// The default value is <see cref="CancellationToken.None"/>.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="voltage"/> is negative, <paramref name="voltage"/> exceeds
+    /// <paramref name="referenceVoltage"/>, or <paramref name="referenceVoltage"/> is negative.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="voltage"/> or <paramref name="referenceVoltage"/> is
+    /// <see cref="double.NaN"/>, <see cref="double.PositiveInfinity"/> or <see cref="double.NegativeInfinity"/>.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This method calculates the 5-bit raw value (0-31) using the following formula,
+    /// rounding the result to the nearest integer (away from zero):
+    /// <c>
+    ///   OutputValue = <see cref="Math.Round(double, MidpointRounding)"/>(31 * <paramref name="voltage"/> / <paramref name="referenceVoltage"/>, <see cref="MidpointRounding.AwayFromZero"/>);
+    /// </c>
+    /// The resulting value is clamped to the range 0 to 31 and applied to the DAC module.
+    /// </para>
+    /// <para>
+    /// If <paramref name="referenceVoltage"/> is <c>0.0</c>, this method always sets
+    /// <c>0</c> for the DAC output regardless of the value of <paramref name="voltage"/>.
+    /// </para>
+    /// <para>
+    /// Unlike the overload that uses the current VRM configuration, this method
+    /// uses the provided <paramref name="referenceVoltage"/> for calculation
+    /// regardless of the actual <see cref="IGpControllerGroup.CurrentDacReferenceSource"/>
+    /// setting.
+    /// </para>
+    /// <para>
+    /// Note that this method does not change the hardware's reference voltage source
+    /// configuration; it only affects the output raw value.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="IGpControllerGroup.ApplyDacRawValue"/>
+    public void WriteAnalogVoltage(
+      double voltage,
+      double referenceVoltage,
+      CancellationToken cancellationToken = default
+    )
+    {
+      ThrowIfThisArgumentIsNull(gpPins, nameof(gpPins));
+
+      gpPins.ApplyDacRawValue(
+        value: DacVoltageConverter.ToOutputValue(
+          voltage: voltage,
+          referenceVoltage: referenceVoltage
+        ),
+        cancellationToken: cancellationToken
+      );
+    }
+
+    /// <summary>
+    /// Asynchronously sets the DAC output to the specified voltage [V] based on the
+    /// specified reference voltage value.
+    /// </summary>
+    /// <inheritdoc cref="WriteAnalogVoltage(IGpControllerGroup, double, double, CancellationToken)"/>
+    public ValueTask WriteAnalogVoltageAsync(
+      double voltage,
+      double referenceVoltage,
+      CancellationToken cancellationToken = default
+    )
+    {
+      ThrowIfThisArgumentIsNull(gpPins, nameof(gpPins));
+
+      return gpPins.ApplyDacRawValueAsync(
+        value: DacVoltageConverter.ToOutputValue(
+          voltage: voltage,
+          referenceVoltage: referenceVoltage
+        ),
+        cancellationToken: cancellationToken
+      );
+    }
   }
 }

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221AController.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221AController.cs
@@ -82,6 +82,44 @@ public partial class Mcp2221AController :
   }
 
   /// <summary>
+  /// Gets the current voltage reference source configured for the DAC module.
+  /// </summary>
+  /// <remarks>
+  /// This property represents the global configuration for the DAC module
+  /// of the MCP2221A. Changing the reference source on one GP pin will
+  /// affect all other GP pins configured as DAC outputs.
+  /// </remarks>
+  /// <seealso cref="Gp2Controller.ConfigureAsDac"/>
+  /// <seealso cref="Gp3Controller.ConfigureAsDac"/>
+  /// <seealso cref="IDacController.CurrentDacReferenceSource"/>
+  public VoltageReferenceSource CurrentDacReferenceSource {
+    get {
+      ThrowIfDisposed();
+      return gpioDriver.CurrentDacReferenceSource;
+    }
+  }
+
+  /// <summary>
+  /// Gets the 5-bit raw output value (0-31) that was last written to the
+  /// DAC module.
+  /// </summary>
+  /// <remarks>
+  /// This property represents the global configuration for the DAC module
+  /// of the MCP2221A. If no write operation has been performed yet, this
+  /// property returns the value currently held by the controller (e.g.,
+  /// the default value from Flash settings).
+  /// </remarks>
+  /// <seealso cref="Gp2Controller.ConfigureAsDac"/>
+  /// <seealso cref="Gp3Controller.ConfigureAsDac"/>
+  /// <seealso cref="IDacController.LastWriteAnalogRawValue"/>
+  public int LastWriteAnalogRawValue {
+    get {
+      ThrowIfDisposed();
+      return gpioDriver.GetLastAppliedDacRawValue();
+    }
+  }
+
+  /// <summary>
   /// Gets the current voltage reference source configured for the ADC module.
   /// </summary>
   /// <remarks>

--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/SramSettings.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/SramSettings.cs
@@ -149,6 +149,12 @@ internal sealed class SramSettings {
     }
   }
 
+  public byte ReadDacVoltageReferenceByte()
+    => settings[OffsetOfDacVoltageReference];
+
+  public byte ReadDacOutputValueByte()
+    => settings[OffsetOfDacOutputValue];
+
   public byte ReadAdcVoltageReferenceByte()
     => settings[OffsetOfAdcVoltageReference];
 

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IAdcController.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IAdcController.cs
@@ -183,16 +183,6 @@ partial class GpControllerTests {
     );
   }
 
-  private static IEnumerable<VoltageReferenceSource> YieldTestCases_UnsupportedVoltageReferenceSource()
-  {
-    yield return (VoltageReferenceSource)(-1);
-    yield return (VoltageReferenceSource)0b_0_0000_01_0; // VRM 4.096 + ADC voltage reference is VDD
-    yield return (VoltageReferenceSource)0b_0_0000_10_0; // VRM 2.048 + ADC voltage reference is VDD
-    yield return (VoltageReferenceSource)0b_0_0000_11_0; // VRM 1.024 + ADC voltage reference is VDD
-    yield return (VoltageReferenceSource)0b_1_1111_00_0;
-    yield return (VoltageReferenceSource)0b_1_1111_11_1;
-  }
-
   [TestCaseSource(nameof(YieldTestCases_UnsupportedVoltageReferenceSource))]
   public void ConfigureAsAdcAsync_UnsupportedVoltageReferenceSource(VoltageReferenceSource voltageReferenceSource)
     => ConfigureAsAdcSyncOrAsync_UnsupportedVoltageReferenceSource(

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IDacController.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IDacController.cs
@@ -1,0 +1,975 @@
+// SPDX-FileCopyrightText: 2026 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using SequenceIs = Smdn.Test.NUnit.Constraints.Buffers.Is;
+
+namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio;
+
+#pragma warning disable IDE0040
+partial class GpControllerTests {
+#pragma warning restore IDE0040
+  private static System.Collections.IEnumerable YieldTestCases_ConfigureAsDacSyncOrAsync()
+  {
+    const byte InitialChipSettings2_DacVrm = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+    const byte InitialChipSettings2_DacVdd = 0b_00_0_00111; // DAC: VDD; Output = 7
+
+    for (var gpIndex = 2; gpIndex <= 3; gpIndex++) {
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVrm, VoltageReferenceSource.Vdd };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVrm, VoltageReferenceSource.VrmOff };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVrm, VoltageReferenceSource.Vrm1024 };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVrm, VoltageReferenceSource.Vrm2048 };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVrm, VoltageReferenceSource.Vrm4096 };
+
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVdd, VoltageReferenceSource.Vdd };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVdd, VoltageReferenceSource.VrmOff };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVdd, VoltageReferenceSource.Vrm1024 };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVdd, VoltageReferenceSource.Vrm2048 };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVdd, VoltageReferenceSource.Vrm4096 };
+    }
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ConfigureAsDacSyncOrAsync))]
+  public void ConfigureAsDacAsync(
+    int gpIndex,
+    byte initialChipSettings2,
+    VoltageReferenceSource voltageReferenceSource
+  )
+    => ConfigureAsDacSyncOrAsync(
+      gpIndex,
+      initialChipSettings2,
+      voltageReferenceSource,
+      static async (gp, vr) => await ((IDacController)gp).ConfigureAsDacAsync(voltageReferenceSource: vr).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ConfigureAsDacSyncOrAsync))]
+  public void ConfigureAsDac(
+    int gpIndex,
+    byte initialChipSettings2,
+    VoltageReferenceSource voltageReferenceSource
+  )
+    => ConfigureAsDacSyncOrAsync(
+      gpIndex,
+      initialChipSettings2,
+      voltageReferenceSource,
+      static (gp, vr) => {
+        ((IDacController)gp).ConfigureAsDac(voltageReferenceSource: vr);
+        return default;
+      }
+    );
+
+  private void ConfigureAsDacSyncOrAsync(
+    int gpIndex,
+    byte initialChipSettings2,
+    VoltageReferenceSource voltageReferenceSource,
+    Func<GpController, VoltageReferenceSource, ValueTask> configureAsDacAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+
+    var initialDacRawValue = initialChipSettings2 & 0b_0_00_11111;
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings2: initialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    var expectedAssignments = mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList();
+    var currentGpSettings = new byte[4] { InitialGp0Settings, InitialGp1Settings, InitialGp2Settings, InitialGp3Settings };
+
+    if (voltageReferenceSource == VoltageReferenceSource.Vdd) {
+      Mcp2221AControllerTests.AppendPseudoResponse(
+        mcp2221A,
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+      );
+    }
+    else {
+      Mcp2221AControllerTests.AppendPseudoResponse(
+        mcp2221A,
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62)),
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS (response to the command to re-enable VRM)
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+      );
+    }
+
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    expectedAssignments[gpIndex] = GpFunction.Dac;
+
+    var expectedVoltageReferenceBits = voltageReferenceSource switch {
+      VoltageReferenceSource.Vdd => 0b_0_0000_00_0,
+      VoltageReferenceSource.VrmOff => 0b_0_0000_00_1,
+      VoltageReferenceSource.Vrm1024 => 0b_0_0000_01_1,
+      VoltageReferenceSource.Vrm2048 => 0b_0_0000_10_1,
+      VoltageReferenceSource.Vrm4096 => 0b_0_0000_11_1,
+      _ => throw new InvalidOperationException(),
+    };
+    const byte ExpectedDesignationBits = 0b_000_0_0_011; // DAC1/DAC2
+
+    currentGpSettings[gpIndex] = (byte)((currentGpSettings[gpIndex] & 0b_1_1111_00_0) | ExpectedDesignationBits);
+
+    var expectedSentSramSettingsCommand = new byte[64];
+
+    expectedSentSramSettingsCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+    // [1-2] don't care
+    expectedSentSramSettingsCommand[3] = (byte)(0b10000000 | expectedVoltageReferenceBits); // [3] DAC Voltage Reference
+    expectedSentSramSettingsCommand[4] = (byte)(0b_0_00_00000 | initialDacRawValue); // [4] Set DAC Output Value
+    // [5-6] don't care
+    expectedSentSramSettingsCommand[7] = 0b10000000; // [7] Alter GPIO configuration = Alter the GP designation (1)
+    expectedSentSramSettingsCommand[8] = currentGpSettings[0]; // [8] GP0 settings
+    expectedSentSramSettingsCommand[9] = currentGpSettings[1]; // [9] GP1 settings
+    expectedSentSramSettingsCommand[10] = currentGpSettings[2]; // [10] GP2 settings
+    expectedSentSramSettingsCommand[11] = currentGpSettings[3]; // [11] GP3 settings
+
+    var expectedSentReenableVrmCommand = new byte[64];
+
+    expectedSentReenableVrmCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+    // [1-2] don't care
+    expectedSentReenableVrmCommand[3] = (byte)(0b10000000 | expectedVoltageReferenceBits); // [3] DAC Voltage Reference
+    expectedSentReenableVrmCommand[4] = (byte)(0b_0_00_00000 | initialDacRawValue); // [4] Set DAC Output Value
+    // [5-6] don't care
+    expectedSentReenableVrmCommand[7] = 0b00000000; // [7] Alter GPIO configuration = Do not alter the current GP designation (0)
+    expectedSentReenableVrmCommand[8] = currentGpSettings[0]; // [8] GP0 settings
+    expectedSentReenableVrmCommand[9] = currentGpSettings[1]; // [9] GP1 settings
+    expectedSentReenableVrmCommand[10] = currentGpSettings[2]; // [10] GP2 settings
+    expectedSentReenableVrmCommand[11] = currentGpSettings[3]; // [11] GP3 settings
+
+    Assert.That(
+      async () => await configureAsDacAsyncFunc(mcp2221A.GpPins[gpIndex], voltageReferenceSource),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A, 0),
+      SequenceIs.EqualTo(expectedSentSramSettingsCommand)
+    );
+
+    if (voltageReferenceSource != VoltageReferenceSource.Vdd) {
+      Assert.That(
+        Mcp2221AControllerTests.GetSentCommand(mcp2221A, 1),
+        SequenceIs.EqualTo(expectedSentReenableVrmCommand)
+      );
+    }
+
+    Assert.That(mcp2221A.CurrentDacReferenceSource, Is.EqualTo(voltageReferenceSource));
+    Assert.That(mcp2221A.LastWriteAnalogRawValue, Is.EqualTo(initialDacRawValue));
+
+    Assert.That(mcp2221A.GpPins[gpIndex].CurrentFunction, Is.EqualTo(GpFunction.Dac));
+    Assert.That(((IDacController)mcp2221A.GpPins[gpIndex]).CurrentDacReferenceSource, Is.EqualTo(voltageReferenceSource));
+    Assert.That(((IDacController)mcp2221A.GpPins[gpIndex]).LastWriteAnalogRawValue, Is.EqualTo(initialDacRawValue));
+
+    Assert.That(
+      mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList(),
+      Is.EqualTo(expectedAssignments).AsCollection,
+      $"other GP pins must not be configured (except {mcp2221A.GpPins[gpIndex].PinName})"
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_ConfigureAsDacSyncOrAsync_WithInitialOutputValue()
+  {
+    const byte InitialChipSettings2_DacVrm = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+    const byte InitialChipSettings2_DacVdd = 0b_00_0_00111; // DAC: VDD; Output = 7
+
+    for (var gpIndex = 2; gpIndex <= 3; gpIndex++) {
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVrm, VoltageReferenceSource.Vdd, 31 };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVrm, VoltageReferenceSource.VrmOff, 1 };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVrm, VoltageReferenceSource.Vrm1024, 0 };
+
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVdd, VoltageReferenceSource.Vdd, 0 };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVdd, VoltageReferenceSource.VrmOff, 31 };
+      yield return new object[] { gpIndex, InitialChipSettings2_DacVdd, VoltageReferenceSource.Vrm4096, 1 };
+    }
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ConfigureAsDacSyncOrAsync_WithInitialOutputValue))]
+  public void ConfigureAsDacAsync_WithInitialOutputValue(
+    int gpIndex,
+    byte initialChipSettings2,
+    VoltageReferenceSource voltageReferenceSource,
+    int initialOutputValue
+  )
+    => ConfigureAsDacSyncOrAsync_WithInitialOutputValue(
+      gpIndex,
+      initialChipSettings2,
+      voltageReferenceSource,
+      initialOutputValue,
+      static async (gp, vr, val) => await ((IDacController)gp).ConfigureAsDacAsync(
+        voltageReferenceSource: vr,
+        initialOutputValue: val
+      ).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ConfigureAsDacSyncOrAsync_WithInitialOutputValue))]
+  public void ConfigureAsDac_WithInitialOutputValue(
+    int gpIndex,
+    byte initialChipSettings2,
+    VoltageReferenceSource voltageReferenceSource,
+    int initialOutputValue
+  )
+    => ConfigureAsDacSyncOrAsync_WithInitialOutputValue(
+      gpIndex,
+      initialChipSettings2,
+      voltageReferenceSource,
+      initialOutputValue,
+      static (gp, vr, val) => {
+        ((IDacController)gp).ConfigureAsDac(
+          voltageReferenceSource: vr,
+          initialOutputValue: val
+        );
+        return default;
+      }
+    );
+
+  private void ConfigureAsDacSyncOrAsync_WithInitialOutputValue(
+    int gpIndex,
+    byte initialChipSettings2,
+    VoltageReferenceSource voltageReferenceSource,
+    int initialOutputValue,
+    Func<GpController, VoltageReferenceSource, int, ValueTask> configureAsDacAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings2: initialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    var expectedAssignments = mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList();
+    var currentGpSettings = new byte[4] { InitialGp0Settings, InitialGp1Settings, InitialGp2Settings, InitialGp3Settings };
+
+    if (voltageReferenceSource == VoltageReferenceSource.Vdd) {
+      Mcp2221AControllerTests.AppendPseudoResponse(
+        mcp2221A,
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+      );
+    }
+    else {
+      Mcp2221AControllerTests.AppendPseudoResponse(
+        mcp2221A,
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62)),
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS (response to the command to re-enable VRM)
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+      );
+    }
+
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    expectedAssignments[gpIndex] = GpFunction.Dac;
+
+    var expectedVoltageReferenceBits = voltageReferenceSource switch {
+      VoltageReferenceSource.Vdd => 0b_0_0000_00_0,
+      VoltageReferenceSource.VrmOff => 0b_0_0000_00_1,
+      VoltageReferenceSource.Vrm1024 => 0b_0_0000_01_1,
+      VoltageReferenceSource.Vrm2048 => 0b_0_0000_10_1,
+      VoltageReferenceSource.Vrm4096 => 0b_0_0000_11_1,
+      _ => throw new InvalidOperationException(),
+    };
+    const byte ExpectedDesignationBits = 0b_000_0_0_011; // DAC1/DAC2
+
+    currentGpSettings[gpIndex] = (byte)((currentGpSettings[gpIndex] & 0b_1_1111_00_0) | ExpectedDesignationBits);
+
+    var expectedSentSramSettingsCommand = new byte[64];
+
+    expectedSentSramSettingsCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+    // [1-2] don't care
+    expectedSentSramSettingsCommand[3] = (byte)(0b10000000 | expectedVoltageReferenceBits); // [3] DAC Voltage Reference
+    expectedSentSramSettingsCommand[4] = (byte)(0b_1_00_00000 | initialOutputValue); // [4] Set DAC Output Value
+    // [5-6] don't care
+    expectedSentSramSettingsCommand[7] = 0b10000000; // [7] Alter GPIO configuration = Alter the GP designation (1)
+    expectedSentSramSettingsCommand[8] = currentGpSettings[0]; // [8] GP0 settings
+    expectedSentSramSettingsCommand[9] = currentGpSettings[1]; // [9] GP1 settings
+    expectedSentSramSettingsCommand[10] = currentGpSettings[2]; // [10] GP2 settings
+    expectedSentSramSettingsCommand[11] = currentGpSettings[3]; // [11] GP3 settings
+
+    var expectedSentReenableVrmCommand = new byte[64];
+
+    expectedSentReenableVrmCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+    // [1-2] don't care
+    expectedSentReenableVrmCommand[3] = (byte)(0b10000000 | expectedVoltageReferenceBits); // [3] DAC Voltage Reference
+    expectedSentReenableVrmCommand[4] = (byte)(0b_1_00_00000 | initialOutputValue); // [4] Set DAC Output Value
+    // [5-6] don't care
+    expectedSentReenableVrmCommand[7] = 0b00000000; // [7] Alter GPIO configuration = Do not alter the current GP designation (0)
+    expectedSentReenableVrmCommand[8] = currentGpSettings[0]; // [8] GP0 settings
+    expectedSentReenableVrmCommand[9] = currentGpSettings[1]; // [9] GP1 settings
+    expectedSentReenableVrmCommand[10] = currentGpSettings[2]; // [10] GP2 settings
+    expectedSentReenableVrmCommand[11] = currentGpSettings[3]; // [11] GP3 settings
+
+    Assert.That(
+      async () => await configureAsDacAsyncFunc(mcp2221A.GpPins[gpIndex], voltageReferenceSource, initialOutputValue),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A, 0),
+      SequenceIs.EqualTo(expectedSentSramSettingsCommand)
+    );
+
+    if (voltageReferenceSource != VoltageReferenceSource.Vdd) {
+      Assert.That(
+        Mcp2221AControllerTests.GetSentCommand(mcp2221A, 1),
+        SequenceIs.EqualTo(expectedSentReenableVrmCommand)
+      );
+    }
+
+    Assert.That(mcp2221A.CurrentDacReferenceSource, Is.EqualTo(voltageReferenceSource));
+    Assert.That(mcp2221A.LastWriteAnalogRawValue, Is.EqualTo(initialOutputValue));
+
+    Assert.That(mcp2221A.GpPins[gpIndex].CurrentFunction, Is.EqualTo(GpFunction.Dac));
+    Assert.That(((IDacController)mcp2221A.GpPins[gpIndex]).CurrentDacReferenceSource, Is.EqualTo(voltageReferenceSource));
+    Assert.That(((IDacController)mcp2221A.GpPins[gpIndex]).LastWriteAnalogRawValue, Is.EqualTo(initialOutputValue));
+
+    Assert.That(
+      mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList(),
+      Is.EqualTo(expectedAssignments).AsCollection,
+      $"other GP pins must not be configured (except {mcp2221A.GpPins[gpIndex].PinName})"
+    );
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_UnsupportedVoltageReferenceSource))]
+  public void ConfigureAsDacAsync_UnsupportedVoltageReferenceSource(VoltageReferenceSource voltageReferenceSource)
+    => ConfigureAsDacSyncOrAsync_UnsupportedVoltageReferenceSource(
+      voltageReferenceSource,
+      static async (gp, vr) => await ((IDacController)gp).ConfigureAsDacAsync(voltageReferenceSource: vr).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_UnsupportedVoltageReferenceSource))]
+  public void ConfigureAsDac_UnsupportedVoltageReferenceSource(VoltageReferenceSource voltageReferenceSource)
+    => ConfigureAsDacSyncOrAsync_UnsupportedVoltageReferenceSource(
+      voltageReferenceSource,
+      static (gp, vr) => {
+        ((IDacController)gp).ConfigureAsDac(voltageReferenceSource: vr);
+        return default;
+      }
+    );
+
+  private void ConfigureAsDacSyncOrAsync_UnsupportedVoltageReferenceSource(
+    VoltageReferenceSource voltageReferenceSource,
+    Func<GpController, VoltageReferenceSource, ValueTask> configureAsDacAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+    const byte InitialChipSettings2 = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings2: InitialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    var initialAssignments = mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList();
+    var initialDacReferenceSource = mcp2221A.CurrentDacReferenceSource;
+    var initialDacRawValue = mcp2221A.LastWriteAnalogRawValue;
+
+    foreach (var gp in new GpController[] { mcp2221A.GpPin2, mcp2221A.GpPin3 }) {
+      Assert.That(
+        async () => await configureAsDacAsyncFunc(gp, voltageReferenceSource),
+        Throws.TypeOf<NotSupportedException>(),
+        $"unsupported voltage reference source ({gp.PinName}, {voltageReferenceSource})"
+      );
+
+      Assert.That(
+        mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList(),
+        Is.EqualTo(initialAssignments).AsCollection,
+        $"must not be configured ({gp.PinName})"
+      );
+
+      Assert.That(
+        mcp2221A.CurrentDacReferenceSource,
+        Is.EqualTo(initialDacReferenceSource),
+        $"must not be configured ({nameof(mcp2221A.CurrentDacReferenceSource)})"
+      );
+      Assert.That(
+        mcp2221A.LastWriteAnalogRawValue,
+        Is.EqualTo(initialDacRawValue),
+        $"must not be changed ({nameof(mcp2221A.LastWriteAnalogRawValue)})"
+      );
+    }
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_ConfigureAsDacSyncOrAsync_WithInitialOutputValue_OutOfRange()
+  {
+    yield return new object[] { VoltageReferenceSource.Vdd, -1 };
+    yield return new object[] { VoltageReferenceSource.VrmOff, int.MinValue };
+    yield return new object[] { VoltageReferenceSource.Vrm1024, 32 };
+    yield return new object[] { VoltageReferenceSource.Vrm2048, int.MaxValue };
+    yield return new object[] { VoltageReferenceSource.Vrm4096, int.MinValue };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ConfigureAsDacSyncOrAsync_WithInitialOutputValue_OutOfRange))]
+  public void ConfigureAsDacAsync_WithInitialOutputValue_OutOfRange(
+    VoltageReferenceSource voltageReferenceSource,
+    int initialOutputValue
+  )
+    => ConfigureAsDacSyncOrAsync_WithInitialOutputValue_OutOfRange(
+      voltageReferenceSource,
+      initialOutputValue,
+      static async (gp, vr, val) => await ((IDacController)gp).ConfigureAsDacAsync(
+        voltageReferenceSource: vr,
+        initialOutputValue: val
+      ).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ConfigureAsDacSyncOrAsync_WithInitialOutputValue_OutOfRange))]
+  public void ConfigureAsDac_WithInitialOutputValue_OutOfRange(
+    VoltageReferenceSource voltageReferenceSource,
+    int initialOutputValue
+  )
+    => ConfigureAsDacSyncOrAsync_WithInitialOutputValue_OutOfRange(
+      voltageReferenceSource,
+      initialOutputValue,
+      static (gp, vr, val) => {
+        ((IDacController)gp).ConfigureAsDac(
+          voltageReferenceSource: vr,
+          initialOutputValue: val
+        );
+        return default;
+      }
+    );
+
+  private void ConfigureAsDacSyncOrAsync_WithInitialOutputValue_OutOfRange(
+    VoltageReferenceSource voltageReferenceSource,
+    int initialOutputValue,
+    Func<GpController, VoltageReferenceSource, int, ValueTask> configureAsDacAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+    const byte InitialChipSettings2 = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings2: InitialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    var initialAssignments = mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList();
+    var initialDacReferenceSource = mcp2221A.CurrentDacReferenceSource;
+    var initialDacRawValue = mcp2221A.LastWriteAnalogRawValue;
+
+    foreach (var gp in new GpController[] { mcp2221A.GpPin2, mcp2221A.GpPin3 }) {
+      Assert.That(
+        async () => await configureAsDacAsyncFunc(gp, voltageReferenceSource, initialOutputValue),
+        Throws
+          .TypeOf<ArgumentOutOfRangeException>()
+          .With
+          .Property(nameof(ArgumentOutOfRangeException.ParamName))
+          .EqualTo("initialOutputValue")
+          .And
+          .Property(nameof(ArgumentOutOfRangeException.ActualValue))
+          .EqualTo(initialOutputValue),
+        $"DAC output value out of range ({gp.PinName}, {initialOutputValue})"
+      );
+
+      Assert.That(
+        mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList(),
+        Is.EqualTo(initialAssignments).AsCollection,
+        $"must not be configured ({gp.PinName})"
+      );
+
+      Assert.That(
+        mcp2221A.CurrentDacReferenceSource,
+        Is.EqualTo(initialDacReferenceSource),
+        $"must not be configured ({nameof(mcp2221A.CurrentDacReferenceSource)})"
+      );
+      Assert.That(
+        mcp2221A.LastWriteAnalogRawValue,
+        Is.EqualTo(initialDacRawValue),
+        $"must not be changed ({nameof(mcp2221A.LastWriteAnalogRawValue)})"
+      );
+    }
+  }
+
+  [Test]
+  public void ConfigureAsDacAsync_CancellationRequested()
+    => ConfigureAsDacSyncOrAsync_CancellationRequested(
+      static async (gp, ct) => await ((IDacController)gp).ConfigureAsDacAsync(VoltageReferenceSource.Vdd, cancellationToken: ct).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void ConfigureAsDac_CancellationRequested()
+    => ConfigureAsDacSyncOrAsync_CancellationRequested(
+      static (gp, ct) => {
+        ((IDacController)gp).ConfigureAsDac(VoltageReferenceSource.Vdd, cancellationToken: ct);
+        return default;
+      }
+    );
+
+  private void ConfigureAsDacSyncOrAsync_CancellationRequested(
+    Func<GpController, CancellationToken, ValueTask> configureAsDacAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+    const byte InitialChipSettings2 = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings2: InitialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    var initialAssignments = mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList();
+    var initialDacReferenceSource = mcp2221A.CurrentDacReferenceSource;
+    var initialDacRawValue = mcp2221A.LastWriteAnalogRawValue;
+
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    foreach (var gp in new GpController[] { mcp2221A.GpPin2, mcp2221A.GpPin3 }) {
+      Assert.That(
+        async () => await configureAsDacAsyncFunc(gp, cts.Token),
+        Throws
+          .TypeOf<OperationCanceledException>()
+          .With
+          .Property(nameof(OperationCanceledException.CancellationToken))
+          .EqualTo(cts.Token),
+        $"cancellation requested ({gp.PinName})"
+      );
+
+      Assert.That(
+        mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList(),
+        Is.EqualTo(initialAssignments).AsCollection,
+        $"must not be configured ({gp.PinName})"
+      );
+
+      Assert.That(
+        mcp2221A.CurrentDacReferenceSource,
+        Is.EqualTo(initialDacReferenceSource),
+        $"must not be configured ({nameof(mcp2221A.CurrentDacReferenceSource)})"
+      );
+      Assert.That(
+        mcp2221A.LastWriteAnalogRawValue,
+        Is.EqualTo(initialDacRawValue),
+        $"must not be changed ({nameof(mcp2221A.LastWriteAnalogRawValue)})"
+      );
+    }
+  }
+
+  [Test]
+  public void ConfigureAsDacAsync_Disposed()
+    => ConfigureAsDacSyncOrAsync_Disposed(
+      static async gp => await ((IDacController)gp).ConfigureAsDacAsync(VoltageReferenceSource.Vdd).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void ConfigureAsDac_Disposed()
+    => ConfigureAsDacSyncOrAsync_Disposed(
+      static gp => {
+        ((IDacController)gp).ConfigureAsDac(VoltageReferenceSource.Vdd);
+        return default;
+      }
+    );
+
+  private void ConfigureAsDacSyncOrAsync_Disposed(
+    Func<GpController, ValueTask> configureAsDacAsyncFunc
+  )
+  {
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true
+    );
+    var dacPins = new GpController[] { mcp2221A.GpPin2, mcp2221A.GpPin3 };
+
+    mcp2221A.Dispose();
+
+    foreach (var gp in dacPins) {
+      Assert.That(
+        async () => await configureAsDacAsyncFunc(gp),
+        Throws.TypeOf<ObjectDisposedException>(),
+        $"object disposed ({gp.PinName})"
+      );
+    }
+  }
+
+  private static IEnumerable<byte> YieldTestCases_WriteAnalogRawSyncAndAsync_GP2_InvalidConfiguration()
+  {
+    yield return 0b_000_1_0_000; // GPIO2
+    yield return 0b_000_1_0_010; // ADC2
+    yield return 0b_000_1_0_001; // USBCFG
+  }
+
+  private static IEnumerable<byte> YieldTestCases_WriteAnalogRawSyncAndAsync_GP3_InvalidConfiguration()
+  {
+    yield return 0b_000_1_0_000; // GPIO3
+    yield return 0b_000_1_0_010; // ADC3
+    yield return 0b_000_1_0_001; // LED_I2C
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogRawSyncAndAsync_GP2_InvalidConfiguration))]
+  public void WriteAnalogRawAsync_GP2_InvalidConfiguration(byte gp2Settings)
+    => WriteAnalogRawSyncAndAsync_InvalidConfiguration(
+      gp2Settings: gp2Settings,
+      gp3Settings: null,
+      expectedDacPinNumberInExceptionMessage: 2,
+      static async mcp2221a => await mcp2221a.GpPin2.WriteAnalogRawAsync(0).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogRawSyncAndAsync_GP2_InvalidConfiguration))]
+  public void WriteAnalogRaw_GP2_InvalidConfiguration(byte gp2Settings)
+    => WriteAnalogRawSyncAndAsync_InvalidConfiguration(
+      gp2Settings: gp2Settings,
+      gp3Settings: null,
+      expectedDacPinNumberInExceptionMessage: 2,
+      static mcp2221a => {
+        mcp2221a.GpPin2.WriteAnalogRaw(0);
+        return default;
+      }
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogRawSyncAndAsync_GP3_InvalidConfiguration))]
+  public void WriteAnalogRawAsync_GP3_InvalidConfiguration(byte gp3Settings)
+    => WriteAnalogRawSyncAndAsync_InvalidConfiguration(
+      gp2Settings: null,
+      gp3Settings: gp3Settings,
+      expectedDacPinNumberInExceptionMessage: 3,
+      static async mcp2221a => await mcp2221a.GpPin3.WriteAnalogRawAsync(0).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogRawSyncAndAsync_GP3_InvalidConfiguration))]
+  public void WriteAnalogRaw_GP3_InvalidConfiguration(byte gp3Settings)
+    => WriteAnalogRawSyncAndAsync_InvalidConfiguration(
+      gp2Settings: null,
+      gp3Settings: gp3Settings,
+      expectedDacPinNumberInExceptionMessage: 3,
+      static mcp2221a => {
+        mcp2221a.GpPin3.WriteAnalogRaw(0);
+        return default;
+      }
+    );
+
+  private void WriteAnalogRawSyncAndAsync_InvalidConfiguration(
+    byte? gp2Settings,
+    byte? gp3Settings,
+    int expectedDacPinNumberInExceptionMessage,
+    Func<Mcp2221AController, ValueTask> writeAnalogRawAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+    const byte InitialChipSettings2 = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: gp2Settings ?? InitialGp2Settings,
+        gp3Settings: gp3Settings ?? InitialGp3Settings,
+        chipSettings2: InitialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    var initialDacRawValue = mcp2221A.LastWriteAnalogRawValue;
+
+    Assert.That(
+      async () => await writeAnalogRawAsyncFunc(mcp2221A),
+      Throws
+        .InvalidOperationException
+        .With
+        .Property(nameof(InvalidOperationException.Message))
+        .Contains($"GP{expectedDacPinNumberInExceptionMessage}")
+    );
+
+    Assert.That(
+      mcp2221A.LastWriteAnalogRawValue,
+      Is.EqualTo(initialDacRawValue),
+      $"must not be changed ({nameof(mcp2221A.LastWriteAnalogRawValue)})"
+    );
+  }
+
+  [Test]
+  public void WriteAnalogRawAsync_Disposed()
+    => WriteAnalogRawSyncOrAsync_Disposed(
+      static async gp => await ((IDacController)gp).WriteAnalogRawAsync(0).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void WriteAnalogRaw_Disposed()
+    => WriteAnalogRawSyncOrAsync_Disposed(
+      static gp => {
+        ((IDacController)gp).WriteAnalogRaw(0);
+        return default;
+      }
+    );
+
+  private void WriteAnalogRawSyncOrAsync_Disposed(
+    Func<GpController, ValueTask> writeAnalogRawAsyncFunc
+  )
+  {
+    using var mcp2221A = CreateMcp2221AConfiguredAsDac();
+    var dacPins = new GpController[] { mcp2221A.GpPin2, mcp2221A.GpPin3 };
+
+    mcp2221A.Dispose();
+
+    foreach (var gp in dacPins) {
+      Assert.That(
+        async () => await writeAnalogRawAsyncFunc(gp),
+        Throws.TypeOf<ObjectDisposedException>(),
+        $"object disposed ({gp.PinName})"
+      );
+    }
+  }
+
+  [Test]
+  public void WriteAnalogRawAsync_CancellationRequested()
+    => WriteAnalogRawSyncOrAsync_CancellationRequested(
+      static async (gp, ct) => await ((IDacController)gp).WriteAnalogRawAsync(0, ct).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void WriteAnalogRaw_CancellationRequested()
+    => WriteAnalogRawSyncOrAsync_CancellationRequested(
+      static (gp, ct) => {
+        ((IDacController)gp).WriteAnalogRaw(0, ct);
+        return default;
+      }
+    );
+
+  private void WriteAnalogRawSyncOrAsync_CancellationRequested(
+    Func<GpController, CancellationToken, ValueTask> writeAnalogRawAsyncFunc
+  )
+  {
+    using var mcp2221A = CreateMcp2221AConfiguredAsDac();
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    foreach (var gp in new GpController[] { mcp2221A.GpPin2, mcp2221A.GpPin3 }) {
+      Assert.That(
+        async () => await writeAnalogRawAsyncFunc(gp, cts.Token),
+        Throws
+          .TypeOf<OperationCanceledException>()
+          .With
+          .Property(nameof(OperationCanceledException.CancellationToken))
+          .EqualTo(cts.Token),
+        $"cancellation requested ({gp.PinName})"
+      );
+    }
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_WriteAnalogRawSyncOrAsync_ValueOutOfRange()
+  {
+    yield return new object[] { int.MinValue };
+    yield return new object[] { -1 };
+    yield return new object[] { 32 };
+    yield return new object[] { int.MaxValue };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogRawSyncOrAsync_ValueOutOfRange))]
+  public void WriteAnalogRawAsync_ValueOutOfRange(int value)
+    => WriteAnalogRawSyncOrAsync_ValueOutOfRange(
+      value,
+      static async (gp, val) => await ((IDacController)gp).WriteAnalogRawAsync(val).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogRawSyncOrAsync_ValueOutOfRange))]
+  public void WriteAnalogRaw_ValueOutOfRange(int value)
+    => WriteAnalogRawSyncOrAsync_ValueOutOfRange(
+      value,
+      static (gp, val) => {
+        ((IDacController)gp).WriteAnalogRaw(val);
+        return default;
+      }
+    );
+
+  private void WriteAnalogRawSyncOrAsync_ValueOutOfRange(
+    int value,
+    Func<GpController, int, ValueTask> writeAnalogRawAsyncFunc
+  )
+  {
+    using var mcp2221A = CreateMcp2221AConfiguredAsDac();
+    var initialDacRawValue = mcp2221A.LastWriteAnalogRawValue;
+
+    foreach (var gp in new GpController[] { mcp2221A.GpPin2, mcp2221A.GpPin3 }) {
+      Assert.That(
+        async () => await writeAnalogRawAsyncFunc(gp, value),
+        Throws
+          .TypeOf<ArgumentOutOfRangeException>()
+          .With
+          .Property(nameof(ArgumentOutOfRangeException.ParamName))
+          .EqualTo("value")
+          .And
+          .Property(nameof(ArgumentOutOfRangeException.ActualValue))
+          .EqualTo(value),
+        $"DAC output value out of range ({gp.PinName}, {value})"
+      );
+
+      Assert.That(
+        mcp2221A.LastWriteAnalogRawValue,
+        Is.EqualTo(initialDacRawValue),
+        $"must not be changed ({nameof(mcp2221A.LastWriteAnalogRawValue)})"
+      );
+    }
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_WriteAnalogRawSyncOrAsync()
+  {
+    const byte InitialChipSettings2_DacVrm = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+    const byte InitialChipSettings2_DacVdd = 0b_00_0_00111; // DAC: VDD; Output = 7
+
+    yield return new object[] { InitialChipSettings2_DacVrm, 0 };
+    yield return new object[] { InitialChipSettings2_DacVdd, 0 };
+
+    yield return new object[] { InitialChipSettings2_DacVrm, 1 };
+    yield return new object[] { InitialChipSettings2_DacVdd, 30 };
+
+    yield return new object[] { InitialChipSettings2_DacVrm, 31 };
+    yield return new object[] { InitialChipSettings2_DacVdd, 31 };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogRawSyncOrAsync))]
+  public ValueTask WriteAnalogRawAsync_GP2(
+    byte chipSettings2,
+    int value
+  )
+    => WriteAnalogRawSyncOrAsync(
+      chipSettings2: chipSettings2,
+      value: value,
+      static async (mcp2221a, value) => await mcp2221a.GpPin2.WriteAnalogRawAsync(value).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogRawSyncOrAsync))]
+  public ValueTask WriteAnalogRaw_GP2(
+    byte chipSettings2,
+    int value
+  )
+    => WriteAnalogRawSyncOrAsync(
+      chipSettings2: chipSettings2,
+      value: value,
+      static (mcp2221a, value) => {
+        mcp2221a.GpPin2.WriteAnalogRaw(value);
+        return default;
+      }
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogRawSyncOrAsync))]
+  public ValueTask WriteAnalogRawAsync_GP3(
+    byte chipSettings2,
+    int value
+  )
+    => WriteAnalogRawSyncOrAsync(
+      chipSettings2: chipSettings2,
+      value: value,
+      static async (mcp2221a, value) => await mcp2221a.GpPin3.WriteAnalogRawAsync(value).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogRawSyncOrAsync))]
+  public ValueTask WriteAnalogRaw_GP3(
+    byte chipSettings2,
+    int value
+  )
+    => WriteAnalogRawSyncOrAsync(
+      chipSettings2: chipSettings2,
+      value: value,
+      static (mcp2221a, value) => {
+        mcp2221a.GpPin2.WriteAnalogRaw(value);
+        return default;
+      }
+    );
+
+  private async ValueTask WriteAnalogRawSyncOrAsync(
+    byte chipSettings2,
+    int value,
+    Func<Mcp2221AController, int, ValueTask> writeAnalogRawAsyncFunc
+  )
+  {
+    using var mcp2221A = CreateMcp2221AConfiguredAsDac(chipSettings2);
+
+    Mcp2221AControllerTests.AppendPseudoResponse(
+      mcp2221A,
+      // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+      // [1] 0x00: Command completed successfully
+      // [2-63] Don't care
+      "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+    );
+
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    var expectedSentCommand = new byte[8];
+
+    expectedSentCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+    // [1-2] don't care
+    expectedSentCommand[3] = (byte)(chipSettings2 >> 5); // [3] DAC Voltage Reference
+    expectedSentCommand[4] = (byte)(0b_1_00_00000 | value); // [4] Set DAC Output Value
+    // [5-6] don't care
+    expectedSentCommand[7] = 0; // [7] Alter GPIO configuration = Do not alter the current GP designation (0)
+    // [8-11] GP0-GP3 settings: No assertions are to be made in this test case.
+
+    Assert.That(
+      async () => await writeAnalogRawAsyncFunc(mcp2221A, value),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A, 0).Slice(0, expectedSentCommand.Length),
+      SequenceIs.EqualTo(expectedSentCommand)
+    );
+
+    Assert.That(mcp2221A.LastWriteAnalogRawValue, Is.EqualTo(value));
+
+    Assert.That(((IDacController)mcp2221A.GpPin2).LastWriteAnalogRawValue, Is.EqualTo(value));
+    Assert.That(((IDacController)mcp2221A.GpPin3).LastWriteAnalogRawValue, Is.EqualTo(value));
+  }
+}

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IDacController.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IDacController.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 using System;
 using System.Collections.Generic;
+using System.Device.Gpio;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -529,6 +530,85 @@ partial class GpControllerTests {
         mcp2221A.LastWriteAnalogRawValue,
         Is.EqualTo(initialDacRawValue),
         $"must not be changed ({nameof(mcp2221A.LastWriteAnalogRawValue)})"
+      );
+    }
+  }
+
+  [Test]
+  public void ConfigureAsDacAsync_ThrowsWhenUsedByGpioController()
+    => ConfigureAsDacSyncOrAsync_ThrowsWhenUsedByGpioController(
+      static async gp => await ((IDacController)gp).ConfigureAsDacAsync(VoltageReferenceSource.Vdd, initialOutputValue: 8).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void ConfigureAsDac_ThrowsWhenUsedByGpioController()
+    => ConfigureAsDacSyncOrAsync_ThrowsWhenUsedByGpioController(
+      static gp => {
+        ((IDacController)gp).ConfigureAsDac(VoltageReferenceSource.Vdd, initialOutputValue: 8);
+        return default;
+      }
+    );
+
+  private void ConfigureAsDacSyncOrAsync_ThrowsWhenUsedByGpioController(
+    Func<GpController, ValueTask> configureAsDacAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_1_0_010; // Alternate Function 0 (LED UART RX)
+    const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
+    const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
+    const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    for (var gp = 0; gp < 4; gp++) {
+      Mcp2221AControllerTests.AppendPseudoResponse(
+        mcp2221A,
+        // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+        // [1] 0x00: Command completed successfully
+        // [2-63] Don't care
+        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+      );
+
+      Assert.That(
+        () =>
+#if SYSTEM_DEVICE_GPIO_4_1_0_OR_GREATER
+          _ =
+#endif
+          mcp2221A.GpioController.OpenPin(gp),
+        Throws.Nothing
+      );
+      Assert.That(mcp2221A.GpPins[gp].IsUsedByGpioController, Is.True);
+    }
+
+    foreach (var gp in new GpController[] { mcp2221A.GpPin2, mcp2221A.GpPin3 }) {
+      // command should not be sent
+      // Mcp2221AControllerTests.AppendPseudoResponse(...);
+      Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+      Assert.That(
+        async () => await configureAsDacAsyncFunc(gp),
+        Throws
+          .InvalidOperationException
+          .With
+          .Property(nameof(InvalidOperationException.Message))
+          .Contains($"GP{gp.Index}")
+          .And
+          .Property(nameof(InvalidOperationException.Message))
+          .Contains(nameof(GpioController))
+      );
+
+      Assert.That(
+        Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+        Is.Zero,
+        "command should not be sent"
       );
     }
   }

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IGpioController.SetSramSettings.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.IGpioController.SetSramSettings.cs
@@ -125,34 +125,83 @@ partial class GpControllerTests {
     }
   }
 
-  [TestCase(PinMode.Input, true)]
-  [TestCase(PinMode.Input, false)]
-  [TestCase(PinMode.Output, true)]
-  [TestCase(PinMode.Output, false)]
-  public void ConfigureAsGpioAsync_AdcVmrMustBeReenabled(PinMode mode, bool initialValue)
-    => ConfigureAsGpioSyncOrAsync_AdcVmrMustBeReenabled(
+  private static System.Collections.IEnumerable YieldTestCases_ConfigureAsGpioAsync_VmrMustBeReenabled()
+  {
+    const byte ChipSettings2_DacVrm4096 = 0b_11_1_00010; // DAC: VRM 4.096V; Output = 2
+    const byte ChipSettings2_DacVrm2048 = 0b_10_1_00100; // DAC: VRM 2.048V; Output = 4
+    const byte ChipSettings2_DacVrm1024 = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+    const byte ChipSettings2_DacVrmOff = 0b_00_1_00001; // DAC: VRM Off; Output = 1
+    const byte ChipSettings2_DacVdd = 0b_00_0_11111; // DAC: Vdd; Output = 31
+    const byte ChipSettings3_AdcVrm4096 = 0b_0_1_1_11_1_00; // ADC: VRM 4.096V
+    const byte ChipSettings3_AdcVrm2048 = 0b_0_1_1_10_1_00; // ADC: VRM 2.048V
+    const byte ChipSettings3_AdcVrm1024 = 0b_0_1_1_01_1_00; // ADC: VRM 1.024V (factory default)
+    const byte ChipSettings3_AdcVrmOff = 0b_0_1_1_00_1_00; // ADC: VRM Off
+    const byte ChipSettings3_AdcVdd = 0b_0_1_1_00_0_00; // ADC: Vdd
+
+    const bool ShouldReenableDacVrm = true;
+    const bool ShouldReenableAdcVrm = true;
+    const bool ShouldNotReenableVrm = false;
+
+    foreach (var mode in new[] { PinMode.Output, PinMode.Input }) {
+      foreach (var initialValue in new[] { PinValue.High, PinValue.Low }) {
+        yield return new object[] { ChipSettings2_DacVrm1024, ChipSettings3_AdcVrm4096, mode, initialValue, ShouldReenableDacVrm, ShouldReenableAdcVrm };
+        yield return new object[] { ChipSettings2_DacVrm2048, ChipSettings3_AdcVrmOff, mode, initialValue, ShouldReenableDacVrm, ShouldReenableAdcVrm };
+        yield return new object[] { ChipSettings2_DacVrmOff, ChipSettings3_AdcVrm2048, mode, initialValue, ShouldReenableDacVrm, ShouldReenableAdcVrm };
+        yield return new object[] { ChipSettings2_DacVdd, ChipSettings3_AdcVrm1024, mode, initialValue, ShouldNotReenableVrm, ShouldReenableAdcVrm };
+        yield return new object[] { ChipSettings2_DacVrm4096, ChipSettings3_AdcVdd, mode, initialValue, ShouldReenableDacVrm, ShouldNotReenableVrm };
+        yield return new object[] { ChipSettings2_DacVdd, ChipSettings3_AdcVdd, mode, initialValue, ShouldNotReenableVrm, ShouldNotReenableVrm };
+      }
+    }
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ConfigureAsGpioAsync_VmrMustBeReenabled))]
+  public void ConfigureAsGpioAsync_VmrMustBeReenabled(
+    byte chipSettings2,
+    byte chipSettings3,
+    PinMode mode,
+    PinValue initialValue,
+    bool shouldReenableDacVrm,
+    bool shouldReenableAdcVrm
+  )
+    => ConfigureAsGpioSyncOrAsync_VmrMustBeReenabled(
+      chipSettings2,
+      chipSettings3,
       mode,
-      (PinValue)initialValue,
+      initialValue,
+      shouldReenableDacVrm,
+      shouldReenableAdcVrm,
       static async (gp, m, val) => await gp.ConfigureAsGpioAsync(mode: m, initialValue: val).ConfigureAwait(false)
     );
 
-  [TestCase(PinMode.Input, true)]
-  [TestCase(PinMode.Input, false)]
-  [TestCase(PinMode.Output, true)]
-  [TestCase(PinMode.Output, false)]
-  public void ConfigureAsGpio_AdcVmrMustBeReenabled(PinMode mode, bool initialValue)
-    => ConfigureAsGpioSyncOrAsync_AdcVmrMustBeReenabled(
+  [TestCaseSource(nameof(YieldTestCases_ConfigureAsGpioAsync_VmrMustBeReenabled))]
+  public void ConfigureAsGpio_VmrMustBeReenabled(
+    byte chipSettings2,
+    byte chipSettings3,
+    PinMode mode,
+    PinValue initialValue,
+    bool shouldReenableDacVrm,
+    bool shouldReenableAdcVrm
+  )
+    => ConfigureAsGpioSyncOrAsync_VmrMustBeReenabled(
+      chipSettings2,
+      chipSettings3,
       mode,
-      (PinValue)initialValue,
+      initialValue,
+      shouldReenableDacVrm,
+      shouldReenableAdcVrm,
       static (gp, m, val) => {
         gp.ConfigureAsGpio(mode: m, initialValue: val);
         return default;
       }
     );
 
-  private void ConfigureAsGpioSyncOrAsync_AdcVmrMustBeReenabled(
+  private void ConfigureAsGpioSyncOrAsync_VmrMustBeReenabled(
+    byte chipSettings2,
+    byte chipSettings3,
     PinMode mode,
     PinValue initialValue,
+    bool shouldReenableDacVrm,
+    bool shouldReenableAdcVrm,
     Func<GpController, PinMode, PinValue, ValueTask> configureAsGpioAsyncFunc
   )
   {
@@ -160,7 +209,6 @@ partial class GpControllerTests {
     const byte InitialGp1Settings = 0b_000_1_0_011; // Alternate Function 1 (LED UART TX)
     const byte InitialGp2Settings = 0b_000_1_0_001; // Dedicated function operation (USBCFG)
     const byte InitialGp3Settings = 0b_000_1_0_001; // Dedicated function operation (LED I2C)
-    const byte InitialChipSettings3 = 0b_0_1_1_01_1_00; // ADC: VRM 1.024V (factory default)
 
     using var mcp2221A = Mcp2221AController.Create(
       Mcp2221AControllerTests.CreatePseudoDevice(
@@ -168,25 +216,41 @@ partial class GpControllerTests {
         gp1Settings: InitialGp1Settings,
         gp2Settings: InitialGp2Settings,
         gp3Settings: InitialGp3Settings,
-        chipSettings3: InitialChipSettings3
+        chipSettings2: chipSettings2,
+        chipSettings3: chipSettings3
       ),
       shouldDisposeUsbHidDevice: true
     );
+    var expectedDacVoltageReferenceBits = (byte)((chipSettings2 & 0b_11_1_00000) >> 5);
+    var expectedDacOutputValueBits = (byte)(chipSettings2 & 0b_00_0_11111);
+    var expectedAdcVoltageReferenceBits = (byte)((chipSettings3 & 0b_0_0_0_11_1_00) >> 2);
     var expectedAssignments = mcp2221A.GpPins.Select(static gp => gp.CurrentFunction).ToList();
     var currentGpSettings = new byte[4] { InitialGp0Settings, InitialGp1Settings, InitialGp2Settings, InitialGp3Settings };
 
     foreach (var gp in mcp2221A.GpPins) {
-      Mcp2221AControllerTests.AppendPseudoResponse(
-        mcp2221A,
-        // [MCP2221A] 3.1.13 SET SRAM SETTINGS
-        // [1] 0x00: Command completed successfully
-        // [2-63] Don't care
-        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62)),
-        // [MCP2221A] 3.1.13 SET SRAM SETTINGS (response to the command to re-enable VRM)
-        // [1] 0x00: Command completed successfully
-        // [2-63] Don't care
-        "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
-      );
+      if (shouldReenableDacVrm || shouldReenableAdcVrm) {
+        Mcp2221AControllerTests.AppendPseudoResponse(
+          mcp2221A,
+          // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+          // [1] 0x00: Command completed successfully
+          // [2-63] Don't care
+          "60-00-" + string.Join("-", Enumerable.Repeat("00", 62)),
+          // [MCP2221A] 3.1.13 SET SRAM SETTINGS (response to the command to re-enable VRM)
+          // [1] 0x00: Command completed successfully
+          // [2-63] Don't care
+          "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+        );
+      }
+      else {
+        Mcp2221AControllerTests.AppendPseudoResponse(
+          mcp2221A,
+          // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+          // [1] 0x00: Command completed successfully
+          // [2-63] Don't care
+          "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+        );
+      }
+
       Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
 
       expectedAssignments[gp.Index] = GpFunction.Gpio;
@@ -207,8 +271,10 @@ partial class GpControllerTests {
       var expectedSentSramSettingsCommand = new byte[64];
 
       expectedSentSramSettingsCommand[0] = 0x60; // [0] SET SRAM SETTINGS
-      // [1-4] don't care
-      expectedSentSramSettingsCommand[5] = 0b_0_0000_01_1; // [5] ADC Voltage Reference: VRM 1.024V
+      // [1-2] don't care
+      expectedSentSramSettingsCommand[3] = expectedDacVoltageReferenceBits; // [3] DAC Voltage Reference
+      expectedSentSramSettingsCommand[4] = expectedDacOutputValueBits; // [4] Set DAC Output Value
+      expectedSentSramSettingsCommand[5] = expectedAdcVoltageReferenceBits; // [5] ADC Voltage Reference
       // [1-6] don't care
       expectedSentSramSettingsCommand[7] = 0b10000000; // [7] Alter GPIO configuration = Alter the GP designation (1)
       expectedSentSramSettingsCommand[8] = currentGpSettings[0]; // [8] GP0 settings
@@ -219,8 +285,10 @@ partial class GpControllerTests {
       var expectedSentReenableVrmCommand = new byte[64];
 
       expectedSentReenableVrmCommand[0] = 0x60; // [0] SET SRAM SETTINGS
-      // [1-4] don't care
-      expectedSentReenableVrmCommand[5] = 0b_1_0000_01_1; // [5] ADC Voltage Reference: VRM 1.024V
+      // [1-2] don't care
+      expectedSentReenableVrmCommand[3] = (byte)((shouldReenableDacVrm ? 0b_1_0000000 : 0b_0_0000000) | expectedDacVoltageReferenceBits); // [3] DAC Voltage Reference
+      expectedSentReenableVrmCommand[4] = expectedDacOutputValueBits; // [4] Set DAC Output Value
+      expectedSentReenableVrmCommand[5] = (byte)((shouldReenableAdcVrm ? 0b_1_0000000 : 0b_0_0000000) | expectedAdcVoltageReferenceBits); // [5] ADC Voltage Reference
       // [6] don't care
       expectedSentReenableVrmCommand[7] = 0b00000000; // [7] Alter GPIO configuration = Do not alter the current GP designation (0)
       expectedSentReenableVrmCommand[8] = currentGpSettings[0]; // [8] GP0 settings
@@ -232,14 +300,18 @@ partial class GpControllerTests {
         async () => await configureAsGpioAsyncFunc(gp, mode, initialValue),
         Throws.Nothing
       );
+
       Assert.That(
         Mcp2221AControllerTests.GetSentCommand(mcp2221A, 0),
         SequenceIs.EqualTo(expectedSentSramSettingsCommand)
       );
-      Assert.That(
-        Mcp2221AControllerTests.GetSentCommand(mcp2221A, 1),
-        SequenceIs.EqualTo(expectedSentReenableVrmCommand)
-      );
+
+      if (shouldReenableDacVrm || shouldReenableAdcVrm) {
+        Assert.That(
+          Mcp2221AControllerTests.GetSentCommand(mcp2221A, 1),
+          SequenceIs.EqualTo(expectedSentReenableVrmCommand)
+        );
+      }
 
       Assert.That(gp.CurrentFunction, Is.EqualTo(GpFunction.Gpio));
       Assert.That(gp.CurrentMode, Is.EqualTo(mode));
@@ -299,11 +371,7 @@ partial class GpControllerTests {
       shouldDisposeUsbHidDevice: true
     );
 
-    var currentGpSettings = new byte[4] { InitialGp0Settings, InitialGp1Settings, InitialGp2Settings, InitialGp3Settings };
-
     for (var gp = 0; gp < 4; gp++) {
-      currentGpSettings[gp] = (byte)(currentGpSettings[gp] & 0b_111_1_1_000);
-
       Mcp2221AControllerTests.AppendPseudoResponse(
         mcp2221A,
         // [MCP2221A] 3.1.13 SET SRAM SETTINGS

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/GpController.cs
@@ -73,6 +73,27 @@ public partial class GpControllerTests {
     );
   }
 
+  private static Mcp2221AController CreateMcp2221AConfiguredAsDac(
+    byte chipSettings2 = 0b_01_1_01000 // DAC: VRM 1.024V; Output = 8 (factory default)
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp1Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp2Settings = 0b_000_0_0_011; // Alternate Function 1 (DAC1)
+    const byte InitialGp3Settings = 0b_000_0_0_011; // Alternate Function 1 (DAC2)
+
+    return Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings2: chipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+  }
+
   private static IEnumerable<byte> YieldTestCases_GP0_InvalidConfigurationSettings()
   {
     yield return 0b_000_1_0_010; // LED_URX
@@ -99,5 +120,15 @@ public partial class GpControllerTests {
     yield return 0b_000_1_0_011; // DAC2
     yield return 0b_000_1_0_010; // ADC3
     yield return 0b_000_1_0_001; // LED_I2C
+  }
+
+  private static IEnumerable<VoltageReferenceSource> YieldTestCases_UnsupportedVoltageReferenceSource()
+  {
+    yield return (VoltageReferenceSource)(-1);
+    yield return (VoltageReferenceSource)0b_0_0000_01_0; // VRM 4.096 + ADC voltage reference is VDD
+    yield return (VoltageReferenceSource)0b_0_0000_10_0; // VRM 2.048 + ADC voltage reference is VDD
+    yield return (VoltageReferenceSource)0b_0_0000_11_0; // VRM 1.024 + ADC voltage reference is VDD
+    yield return (VoltageReferenceSource)0b_1_1111_00_0;
+    yield return (VoltageReferenceSource)0b_1_1111_11_1;
   }
 }

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.IGpControllerGroup.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.Gpio/Mcp2221AGpioDriver.IGpControllerGroup.cs
@@ -1838,6 +1838,261 @@ partial class Mcp2221AGpioDriverTests {
   }
 
   [Test]
+  public void ApplyDacRawValueAsync_Disposed()
+    => ApplyDacRawValueSyncOrAsync_Disposed(
+      static async gpPins => await gpPins.ApplyDacRawValueAsync(0).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void ApplyDacRawValue_Disposed()
+    => ApplyDacRawValueSyncOrAsync_Disposed(
+      static gpPins => {
+        gpPins.ApplyDacRawValue(0);
+        return default;
+      }
+    );
+
+  private void ApplyDacRawValueSyncOrAsync_Disposed(
+    Func<IGpControllerGroup, ValueTask> applyDacRawValueAsyncFunc
+  )
+  {
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    mcp2221A.Dispose();
+
+    Assert.That(
+      async () => await applyDacRawValueAsyncFunc(mcp2221A.GpPins),
+      Throws.TypeOf<ObjectDisposedException>()
+    );
+  }
+
+  [Test]
+  public void ApplyDacRawValueAsync_CancellationRequested()
+    => ApplyDacRawValueSyncOrAsync_CancellationRequested(
+      static async (gpPins, ct) => await gpPins.ApplyDacRawValueAsync(0, ct).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void ApplyDacRawValue_CancellationRequested()
+    => ApplyDacRawValueSyncOrAsync_CancellationRequested(
+      static (gpPins, ct) => {
+        gpPins.ApplyDacRawValue(0, ct);
+        return default;
+      }
+    );
+
+  private void ApplyDacRawValueSyncOrAsync_CancellationRequested(
+    Func<IGpControllerGroup, CancellationToken, ValueTask> applyDacRawValueAsyncFunc
+  )
+  {
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(),
+      shouldDisposeUsbHidDevice: true
+    );
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    // command should not be sent
+    // Mcp2221AControllerTests.AppendPseudoResponse(...);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    Assert.That(
+      async () => await applyDacRawValueAsyncFunc(mcp2221A.GpPins, cts.Token),
+      Throws
+        .TypeOf<OperationCanceledException>()
+        .With
+        .Property(nameof(OperationCanceledException.CancellationToken))
+        .EqualTo(cts.Token)
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+      Is.Zero,
+      "command should not be sent"
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_ApplyDacRawValueSyncOrAsync_ValueOutOfRange()
+  {
+    yield return new object[] { int.MinValue };
+    yield return new object[] { -1 };
+    yield return new object[] { 32 };
+    yield return new object[] { int.MaxValue };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ApplyDacRawValueSyncOrAsync_ValueOutOfRange))]
+  public void ApplyDacRawValueAsync_ValueOutOfRange(int value)
+    => ApplyDacRawValueSyncOrAsync_ValueOutOfRange(
+      value,
+      static async (gpPins, value) => await gpPins.ApplyDacRawValueAsync(value).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ApplyDacRawValueSyncOrAsync_ValueOutOfRange))]
+  public void ApplyDacRawValue_ValueOutOfRange(int value)
+    => ApplyDacRawValueSyncOrAsync_ValueOutOfRange(
+      value,
+      static (gpPins, value) => {
+        gpPins.ApplyDacRawValue(value);
+        return default;
+      }
+    );
+
+  private void ApplyDacRawValueSyncOrAsync_ValueOutOfRange(
+    int value,
+    Func<IGpControllerGroup, int, ValueTask> applyDacRawValueAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp1Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp2Settings = 0b_000_0_0_011; // Alternate Function 1 (DAC1)
+    const byte InitialGp3Settings = 0b_000_0_0_011; // Alternate Function 1 (DAC2)
+    const byte InitialChipSettings2 = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings2: InitialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    var initialDacRawValue = mcp2221A.LastWriteAnalogRawValue;
+
+    // command should not be sent
+    // Mcp2221AControllerTests.AppendPseudoResponse(...);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    Assert.That(
+      async () => await applyDacRawValueAsyncFunc(mcp2221A.GpPins, value),
+      Throws
+        .TypeOf<ArgumentOutOfRangeException>()
+        .With
+        .Property(nameof(ArgumentOutOfRangeException.ParamName))
+        .EqualTo("value")
+        .And
+        .Property(nameof(ArgumentOutOfRangeException.ActualValue))
+        .EqualTo(value),
+      $"DAC output value out of range ({value})"
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+      Is.Zero,
+      "command should not be sent"
+    );
+
+    Assert.That(
+      mcp2221A.LastWriteAnalogRawValue,
+      Is.EqualTo(initialDacRawValue),
+      $"must not be changed ({nameof(mcp2221A.LastWriteAnalogRawValue)})"
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_ApplyDacRawValueSyncOrAsync()
+  {
+    const byte InitialChipSettings2_DacVrm = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+    const byte InitialChipSettings2_DacVdd = 0b_00_0_00111; // DAC: VDD; Output = 7
+
+    yield return new object[] { InitialChipSettings2_DacVrm, 0 };
+    yield return new object[] { InitialChipSettings2_DacVdd, 0 };
+
+    yield return new object[] { InitialChipSettings2_DacVrm, 1 };
+    yield return new object[] { InitialChipSettings2_DacVdd, 30 };
+
+    yield return new object[] { InitialChipSettings2_DacVrm, 31 };
+    yield return new object[] { InitialChipSettings2_DacVdd, 31 };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_ApplyDacRawValueSyncOrAsync))]
+  public ValueTask ApplyDacRawValueAsync(
+    byte chipSettings2,
+    int value
+  )
+    => ApplyDacRawValueSyncOrAsync(
+      chipSettings2: chipSettings2,
+      value: value,
+      static async (gpPins, value) => await gpPins.ApplyDacRawValueAsync(value).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_ApplyDacRawValueSyncOrAsync))]
+  public ValueTask ApplyDacRawValue(
+    byte chipSettings2,
+    int value
+  )
+    => ApplyDacRawValueSyncOrAsync(
+      chipSettings2: chipSettings2,
+      value: value,
+      static (gpPins, value) => {
+        gpPins.ApplyDacRawValue(value);
+        return default;
+      }
+    );
+
+  private async ValueTask ApplyDacRawValueSyncOrAsync(
+    byte chipSettings2,
+    int value,
+    Func<IGpControllerGroup, int, ValueTask> applyDacRawValueAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp1Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp2Settings = 0b_000_0_0_011; // Alternate Function 1 (DAC1)
+    const byte InitialGp3Settings = 0b_000_0_0_011; // Alternate Function 1 (DAC2)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings2: chipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    Mcp2221AControllerTests.AppendPseudoResponse(
+      mcp2221A,
+      // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+      // [1] 0x00: Command completed successfully
+      // [2-63] Don't care
+      "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+    );
+
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    var expectedSentCommand = new byte[64];
+
+    expectedSentCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+    // [1-2] don't care
+    expectedSentCommand[3] = (byte)(chipSettings2 >> 5); // [3] DAC Voltage Reference
+    expectedSentCommand[4] = (byte)(0b_1_00_00000 | value); // [4] Set DAC Output Value
+    // [5-6] don't care
+    expectedSentCommand[7] = 0; // [7] Alter GPIO configuration = Do not alter the current GP designation (0)
+    expectedSentCommand[8] = InitialGp0Settings; // [8] GP0 settings
+    expectedSentCommand[9] = InitialGp1Settings; // [9] GP1 settings
+    expectedSentCommand[10] = InitialGp2Settings; // [10] GP2 settings
+    expectedSentCommand[11] = InitialGp3Settings; // [11] GP3 settings
+
+    Assert.That(
+      async () => await applyDacRawValueAsyncFunc(mcp2221A.GpPins, value),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A, 0),
+      SequenceIs.EqualTo(expectedSentCommand)
+    );
+
+    Assert.That(mcp2221A.LastWriteAnalogRawValue, Is.EqualTo(value));
+  }
+
+  [Test]
   public void FetchAdcRawValuesAsync_Disposed()
     => FetchAdcRawValuesSyncOrAsync_Disposed(
       static async gpPins => await gpPins.FetchAdcRawValuesAsync().ConfigureAwait(false)

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/IGpControllerGroupExtensions.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/IGpControllerGroupExtensions.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 using Smdn.Devices.Mcp2221A.Peripherals.Gpio;
 
@@ -3508,5 +3509,571 @@ public class IGpControllerGroupExtensionsTests {
     Assert.That(adc1Voltage, Is.EqualTo(expectedAdc1Voltage).Within(1e-9));
     Assert.That(adc2Voltage, Is.EqualTo(expectedAdc2Voltage).Within(1e-9));
     Assert.That(adc3Voltage, Is.EqualTo(expectedAdc3Voltage).Within(1e-9));
+  }
+
+  [Test]
+  public void WriteAnalogVoltageAsync_ArgumentNull()
+  {
+    IGpControllerGroup? gpPins = null;
+
+    Assert.That(
+      () => gpPins!.WriteAnalogVoltageAsync(0.0),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("gpPins")
+    );
+  }
+
+  [Test]
+  public void WriteAnalogVoltage_ArgumentNull()
+  {
+    IGpControllerGroup? gpPins = null;
+
+    Assert.That(
+      () => gpPins!.WriteAnalogVoltage(0.0),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("gpPins")
+    );
+  }
+
+  [Test]
+  public void WriteAnalogVoltageAsync_CancellationRequested()
+    => WriteAnalogVoltageSyncOrAsync_CancellationRequested(
+      static async (gpPins, ct) => await gpPins.WriteAnalogVoltageAsync(0.0, ct).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void WriteAnalogVoltage_CancellationRequested()
+    => WriteAnalogVoltageSyncOrAsync_CancellationRequested(
+      static (gpPins, ct) => {
+        gpPins.WriteAnalogVoltage(0.0, ct);
+        return default;
+      }
+    );
+
+  private void WriteAnalogVoltageSyncOrAsync_CancellationRequested(
+    Func<IGpControllerGroup, CancellationToken, ValueTask> writeAnalogVoltageAsyncFunc
+  )
+  {
+    const byte InitialChipSettings2 = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        chipSettings2: InitialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    // command should not be sent
+    // Mcp2221AControllerTests.AppendPseudoResponse(...);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    Assert.That(
+      async () => await writeAnalogVoltageAsyncFunc(mcp2221A.GpPins, cts.Token),
+      Throws
+        .TypeOf<OperationCanceledException>()
+        .With
+        .Property(nameof(OperationCanceledException.CancellationToken))
+        .EqualTo(cts.Token)
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+      Is.Zero,
+      "command should not be sent"
+    );
+  }
+
+  [Test]
+  public void WriteAnalogVoltageAsync_Vdd()
+    => WriteAnalogVoltageSyncOrAsync_Vdd(
+      static async gpPins => await gpPins.WriteAnalogVoltageAsync(0.0).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void WriteAnalogVoltage_Vdd()
+    => WriteAnalogVoltageSyncOrAsync_Vdd(
+      static gpPins => {
+        gpPins.WriteAnalogVoltage(0.0);
+        return default;
+      }
+    );
+
+  private void WriteAnalogVoltageSyncOrAsync_Vdd(
+    Func<IGpControllerGroup, ValueTask> writeAnalogVoltageAsyncFunc
+  )
+  {
+    const byte InitialChipSettings2 = 0b_00_0_11111; // DAC: VDD; Output = 31
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        chipSettings2: InitialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    // command should not be sent
+    // Mcp2221AControllerTests.AppendPseudoResponse(...);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    Assert.That(
+      async () => await writeAnalogVoltageAsyncFunc(mcp2221A.GpPins),
+      Throws
+        .TypeOf<InvalidOperationException>()
+        .With
+        .Property(nameof(InvalidOperationException.Message))
+        .Contains("Vdd")
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+      Is.Zero,
+      "command should not be sent"
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_WriteAnalogVoltageSyncOrAsync()
+  {
+    const byte InitialChipSettings2_DacVrm1024 = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+    const byte InitialChipSettings2_DacVrm2048 = 0b_10_1_00001; // DAC: VRM 2.048V; Output = 1
+    const byte InitialChipSettings2_DacVrm4096 = 0b_11_1_00010; // DAC: VRM 4.096V; Output = 2
+    const byte InitialChipSettings2_DacVrmOff = 0b_00_1_00100; // DAC: VRM Off; Output = 4
+
+    yield return new object[] { InitialChipSettings2_DacVrm1024, 0.0, 0 };
+    yield return new object[] { InitialChipSettings2_DacVrm1024, 0.033, 1 };
+    yield return new object[] { InitialChipSettings2_DacVrm1024, 0.512, 16 };
+    yield return new object[] { InitialChipSettings2_DacVrm1024, 1.020, 31 };
+    yield return new object[] { InitialChipSettings2_DacVrm1024, 1.024, 31 };
+
+    yield return new object[] { InitialChipSettings2_DacVrm2048, 0.0, 0 };
+    yield return new object[] { InitialChipSettings2_DacVrm2048, 0.066, 1 };
+    yield return new object[] { InitialChipSettings2_DacVrm2048, 1.024, 16 };
+    yield return new object[] { InitialChipSettings2_DacVrm2048, 2.040, 31 };
+    yield return new object[] { InitialChipSettings2_DacVrm2048, 2.048, 31 };
+
+    yield return new object[] { InitialChipSettings2_DacVrm4096, 0.0, 0 };
+    yield return new object[] { InitialChipSettings2_DacVrm4096, 0.132, 1 };
+    yield return new object[] { InitialChipSettings2_DacVrm4096, 2.048, 16 };
+    yield return new object[] { InitialChipSettings2_DacVrm4096, 4.090, 31 };
+    yield return new object[] { InitialChipSettings2_DacVrm4096, 4.096, 31 };
+
+    yield return new object[] { InitialChipSettings2_DacVrmOff, 0.0, 0 };
+    yield return new object[] { InitialChipSettings2_DacVrmOff, 1.0, 0 };
+    yield return new object[] { InitialChipSettings2_DacVrmOff, 5.0, 0 };
+    yield return new object[] { InitialChipSettings2_DacVrmOff, 12.0, 0 };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogVoltageSyncOrAsync))]
+  public void WriteAnalogVoltageAsync(
+    byte chipSettings2,
+    double voltage,
+    int expectedAnalogRawValue
+  )
+    => WriteAnalogVoltageSyncOrAsync(
+      chipSettings2: chipSettings2,
+      voltage: voltage,
+      expectedAnalogRawValue: expectedAnalogRawValue,
+      static async (gpPins, voltage) => await gpPins.WriteAnalogVoltageAsync(voltage).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogVoltageSyncOrAsync))]
+  public void WriteAnalogVoltage(
+    byte chipSettings2,
+    double voltage,
+    int expectedAnalogRawValue
+  )
+    => WriteAnalogVoltageSyncOrAsync(
+      chipSettings2: chipSettings2,
+      voltage: voltage,
+      expectedAnalogRawValue: expectedAnalogRawValue,
+      static (gpPins, voltage) => {
+        gpPins.WriteAnalogVoltage(voltage);
+        return default;
+      }
+    );
+
+  private void WriteAnalogVoltageSyncOrAsync(
+    byte chipSettings2,
+    double voltage,
+    int expectedAnalogRawValue,
+    Func<IGpControllerGroup, double, ValueTask> writeAnalogVoltageAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp1Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp2Settings = 0b_000_0_0_011; // Alternate Function 1 (DAC1)
+    const byte InitialGp3Settings = 0b_000_0_0_011; // Alternate Function 1 (DAC2)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings2: chipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    Mcp2221AControllerTests.AppendPseudoResponse(
+      mcp2221A,
+      // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+      // [1] 0x00: Command completed successfully
+      // [2-63] Don't care
+      "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+    );
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    var expectedSentCommand = new byte[64];
+
+    expectedSentCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+    // [1-2] don't care
+    expectedSentCommand[3] = (byte)(chipSettings2 >> 5); // [3] DAC Voltage Reference
+    expectedSentCommand[4] = (byte)(0b_1_00_00000 | expectedAnalogRawValue); // [4] Set DAC Output Value
+    // [5-6] don't care
+    expectedSentCommand[7] = 0; // [7] Alter GPIO configuration = Do not alter the current GP designation (0)
+    expectedSentCommand[8] = InitialGp0Settings; // [8] GP0 settings
+    expectedSentCommand[9] = InitialGp1Settings; // [9] GP1 settings
+    expectedSentCommand[10] = InitialGp2Settings; // [10] GP2 settings
+    expectedSentCommand[11] = InitialGp3Settings; // [11] GP3 settings
+
+    Assert.That(
+      async () => await writeAnalogVoltageAsyncFunc(mcp2221A.GpPins, voltage),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A, 0),
+      SequenceIs.EqualTo(expectedSentCommand)
+    );
+
+    Assert.That(mcp2221A.LastWriteAnalogRawValue, Is.EqualTo(expectedAnalogRawValue));
+
+    Assert.That(((IDacController)mcp2221A.GpPin2).LastWriteAnalogRawValue, Is.EqualTo(expectedAnalogRawValue));
+    Assert.That(((IDacController)mcp2221A.GpPin3).LastWriteAnalogRawValue, Is.EqualTo(expectedAnalogRawValue));
+  }
+
+  [Test]
+  public void WriteAnalogVoltageAsync_WithReferenceVoltage_ArgumentNull()
+  {
+    IGpControllerGroup? gpPins = null;
+
+    Assert.That(
+      () => gpPins!.WriteAnalogVoltageAsync(0.0, referenceVoltage: 5.0),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("gpPins")
+    );
+  }
+
+  [Test]
+  public void WriteAnalogVoltage_WithReferenceVoltage_ArgumentNull()
+  {
+    IGpControllerGroup? gpPins = null;
+
+    Assert.That(
+      () => gpPins!.WriteAnalogVoltage(0.0, referenceVoltage: 5.0),
+      Throws
+        .ArgumentNullException
+        .With
+        .Property(nameof(ArgumentNullException.ParamName))
+        .EqualTo("gpPins")
+    );
+  }
+
+  [Test]
+  public void WriteAnalogVoltageAsync_WithReferenceVoltage_CancellationRequested()
+    => WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage_CancellationRequested(
+      static async (gpPins, ct) => await gpPins.WriteAnalogVoltageAsync(0.0, referenceVoltage: 5.0, ct).ConfigureAwait(false)
+    );
+
+  [Test]
+  public void WriteAnalogVoltage_WithReferenceVoltage_CancellationRequested()
+    => WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage_CancellationRequested(
+      static (gpPins, ct) => {
+        gpPins.WriteAnalogVoltage(0.0, referenceVoltage: 5.0, ct);
+        return default;
+      }
+    );
+
+  private void WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage_CancellationRequested(
+    Func<IGpControllerGroup, CancellationToken, ValueTask> writeAnalogVoltageAsyncFunc
+  )
+  {
+    const byte InitialChipSettings2 = 0b_01_1_01000; // DAC: VRM 1.024V; Output = 8 (factory default)
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        chipSettings2: InitialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+    using var cts = new CancellationTokenSource();
+
+    cts.Cancel();
+
+    // command should not be sent
+    // Mcp2221AControllerTests.AppendPseudoResponse(...);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    Assert.That(
+      async () => await writeAnalogVoltageAsyncFunc(mcp2221A.GpPins, cts.Token),
+      Throws
+        .TypeOf<OperationCanceledException>()
+        .With
+        .Property(nameof(OperationCanceledException.CancellationToken))
+        .EqualTo(cts.Token)
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+      Is.Zero,
+      "command should not be sent"
+    );
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage()
+  {
+    const double Vdd_5V0 = 5.0;
+    const double Vdd_3V3 = 3.3;
+    const double Vdd_Zero = 0.0;
+
+    yield return new object[] { 0.000, Vdd_5V0, 0 };
+    yield return new object[] { 0.161, Vdd_5V0, 1 };
+    yield return new object[] { 4.999, Vdd_5V0, 31 };
+    yield return new object[] { 5.000, Vdd_5V0, 31 };
+
+    yield return new object[] { 0.0, Vdd_3V3, 0 };
+    yield return new object[] { 0.106, Vdd_3V3, 1 };
+    yield return new object[] { 3.299, Vdd_3V3, 31 };
+    yield return new object[] { 3.300, Vdd_3V3, 31 };
+
+    yield return new object[] { 0.0, Vdd_Zero, 0 };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage))]
+  public void WriteAnalogVoltageAsync_WithReferenceVoltage(
+    double voltage,
+    double referenceVoltage,
+    int expectedAnalogRawValue
+  )
+    => WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage(
+      voltage: voltage,
+      referenceVoltage: referenceVoltage,
+      expectedAnalogRawValue: expectedAnalogRawValue,
+      static async (gpPins, voltage, referenceVoltage) => await gpPins.WriteAnalogVoltageAsync(voltage, referenceVoltage).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage))]
+  public void WriteAnalogVoltage_WithReferenceVoltage(
+    double voltage,
+    double referenceVoltage,
+    int expectedAnalogRawValue
+  )
+    => WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage(
+      voltage: voltage,
+      referenceVoltage: referenceVoltage,
+      expectedAnalogRawValue: expectedAnalogRawValue,
+      static (gpPins, voltage, referenceVoltage) => {
+        gpPins.WriteAnalogVoltage(voltage, referenceVoltage);
+        return default;
+      }
+    );
+
+  private void WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage(
+    double voltage,
+    double referenceVoltage,
+    int expectedAnalogRawValue,
+    Func<IGpControllerGroup, double, double, ValueTask> writeAnalogVoltageAsyncFunc
+  )
+  {
+    const byte InitialGp0Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp1Settings = 0b_000_0_0_000; // GPIO operation
+    const byte InitialGp2Settings = 0b_000_0_0_011; // Alternate Function 1 (DAC1)
+    const byte InitialGp3Settings = 0b_000_0_0_011; // Alternate Function 1 (DAC2)
+    const byte InitialChipSettings2 = 0b_00_0_00000; // DAC: VDD; Output = 0
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        gp0Settings: InitialGp0Settings,
+        gp1Settings: InitialGp1Settings,
+        gp2Settings: InitialGp2Settings,
+        gp3Settings: InitialGp3Settings,
+        chipSettings2: InitialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    Mcp2221AControllerTests.AppendPseudoResponse(
+      mcp2221A,
+      // [MCP2221A] 3.1.13 SET SRAM SETTINGS
+      // [1] 0x00: Command completed successfully
+      // [2-63] Don't care
+      "60-00-" + string.Join("-", Enumerable.Repeat("00", 62))
+    );
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    var expectedSentCommand = new byte[64];
+
+    expectedSentCommand[0] = 0x60; // [0] SET SRAM SETTINGS
+    // [1-2] don't care
+    expectedSentCommand[3] = InitialChipSettings2 >> 5; // [3] DAC Voltage Reference
+    expectedSentCommand[4] = (byte)(0b_1_00_00000 | expectedAnalogRawValue); // [4] Set DAC Output Value
+    // [5-6] don't care
+    expectedSentCommand[7] = 0; // [7] Alter GPIO configuration = Do not alter the current GP designation (0)
+    expectedSentCommand[8] = InitialGp0Settings; // [8] GP0 settings
+    expectedSentCommand[9] = InitialGp1Settings; // [9] GP1 settings
+    expectedSentCommand[10] = InitialGp2Settings; // [10] GP2 settings
+    expectedSentCommand[11] = InitialGp3Settings; // [11] GP3 settings
+
+    Assert.That(
+      async () => await writeAnalogVoltageAsyncFunc(mcp2221A.GpPins, voltage, referenceVoltage),
+      Throws.Nothing
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetSentCommand(mcp2221A, 0),
+      SequenceIs.EqualTo(expectedSentCommand)
+    );
+
+    Assert.That(mcp2221A.LastWriteAnalogRawValue, Is.EqualTo(expectedAnalogRawValue));
+
+    Assert.That(((IDacController)mcp2221A.GpPin2).LastWriteAnalogRawValue, Is.EqualTo(expectedAnalogRawValue));
+    Assert.That(((IDacController)mcp2221A.GpPin3).LastWriteAnalogRawValue, Is.EqualTo(expectedAnalogRawValue));
+  }
+
+  private static System.Collections.IEnumerable YieldTestCases_WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage_ArgumentException()
+  {
+    const double Vdd_5V0 = 5.0;
+    const double Vdd_3V3 = 3.3;
+    const double VrmOff = 0.0;
+    const double Vrm1024 = 1.024;
+    const double Vrm2048 = 2.048;
+    const double Vrm4096 = 4.096;
+
+    const string ParamNameVoltage = "voltage";
+    const string ParamNameReferenceVoltage = "referenceVoltage";
+
+    static IResolveConstraint ThrowsArgumentOutOfRangeException(string expectedParamName, object expectedActualValue)
+      => Throws
+        .TypeOf<ArgumentOutOfRangeException>()
+        .With
+        .Property(nameof(ArgumentOutOfRangeException.ParamName))
+        .EqualTo(expectedParamName)
+        .And
+        .Property(nameof(ArgumentOutOfRangeException.ActualValue))
+        .EqualTo(expectedActualValue);
+
+    static IResolveConstraint ThrowsArgumentException(string expectedParamName)
+      => Throws
+        .TypeOf<ArgumentException>()
+        .With
+        .Property(nameof(ArgumentException.ParamName))
+        .EqualTo(expectedParamName);
+
+    // voltage exceeds referenceVoltage
+    yield return new object[] { 5.05, Vdd_5V0, ThrowsArgumentOutOfRangeException(ParamNameVoltage, 5.05) };
+    yield return new object[] { 3.33, Vdd_3V3, ThrowsArgumentOutOfRangeException(ParamNameVoltage, 3.33) };
+
+    yield return new object[] { 1.025, Vrm1024, ThrowsArgumentOutOfRangeException(ParamNameVoltage, 1.025) };
+    yield return new object[] { 1.1, Vrm1024, ThrowsArgumentOutOfRangeException(ParamNameVoltage, 1.1) };
+
+    yield return new object[] { 2.049, Vrm2048, ThrowsArgumentOutOfRangeException(ParamNameVoltage, 2.049) };
+    yield return new object[] { 2.1, Vrm2048, ThrowsArgumentOutOfRangeException(ParamNameVoltage, 2.1) };
+
+    yield return new object[] { 4.097, Vrm4096, ThrowsArgumentOutOfRangeException(ParamNameVoltage, 4.097) };
+    yield return new object[] { 4.2, Vrm4096, ThrowsArgumentOutOfRangeException(ParamNameVoltage, 4.2) };
+
+    yield return new object[] { 0.1, VrmOff, ThrowsArgumentOutOfRangeException(ParamNameVoltage, 0.1) };
+
+    // voltage exceeds max output value (31)
+    yield return new object[] { 5.1, Vdd_5V0, ThrowsArgumentOutOfRangeException(ParamNameVoltage, 5.1) };
+
+    // negative values
+    yield return new object[] { -0.1, Vdd_5V0, ThrowsArgumentOutOfRangeException(ParamNameVoltage, -0.1) };
+    yield return new object[] { 0.0, -1.0, ThrowsArgumentOutOfRangeException(ParamNameReferenceVoltage, -1.0) };
+    yield return new object[] { -1.0, -1.0, ThrowsArgumentOutOfRangeException(ParamNameVoltage, -1.0) };
+
+    // NaN
+    yield return new object[] { double.NaN, Vdd_5V0, ThrowsArgumentException(ParamNameVoltage) };
+    yield return new object[] { 0.0, double.NaN, ThrowsArgumentException(ParamNameReferenceVoltage) };
+    yield return new object[] { double.NaN, double.NaN, ThrowsArgumentException(ParamNameVoltage) };
+
+    // +/- infinity
+    yield return new object[] { double.PositiveInfinity, Vdd_5V0, ThrowsArgumentException(ParamNameVoltage) };
+    yield return new object[] { double.NegativeInfinity, Vdd_5V0, ThrowsArgumentException(ParamNameVoltage) };
+    yield return new object[] { 0.0, double.PositiveInfinity, ThrowsArgumentException(ParamNameReferenceVoltage) };
+    yield return new object[] { 0.0, double.NegativeInfinity, ThrowsArgumentException(ParamNameReferenceVoltage) };
+  }
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage_ArgumentException))]
+  public void WriteAnalogVoltageAsync_WithReferenceVoltage_ArgumentException(
+    double voltage,
+    double referenceVoltage,
+    IResolveConstraint throwsArgumentExceptionConstraint
+  )
+    => WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage_ArgumentException(
+      voltage: voltage,
+      referenceVoltage: referenceVoltage,
+      throwsArgumentExceptionConstraint: throwsArgumentExceptionConstraint,
+      static async (gpPins, voltage, referenceVoltage) => await gpPins.WriteAnalogVoltageAsync(voltage, referenceVoltage).ConfigureAwait(false)
+    );
+
+  [TestCaseSource(nameof(YieldTestCases_WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage_ArgumentException))]
+  public void WriteAnalogVoltage_WithReferenceVoltage_ArgumentException(
+    double voltage,
+    double referenceVoltage,
+    IResolveConstraint throwsArgumentExceptionConstraint
+  )
+    => WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage_ArgumentException(
+      voltage: voltage,
+      referenceVoltage: referenceVoltage,
+      throwsArgumentExceptionConstraint: throwsArgumentExceptionConstraint,
+      static (gpPins, voltage, referenceVoltage) => {
+        gpPins.WriteAnalogVoltage(voltage, referenceVoltage);
+        return default;
+      }
+    );
+
+  private void WriteAnalogVoltageSyncOrAsync_WithReferenceVoltage_ArgumentException(
+    double voltage,
+    double referenceVoltage,
+    IResolveConstraint throwsArgumentExceptionConstraint,
+    Func<IGpControllerGroup, double, double, ValueTask> writeAnalogVoltageAsyncFunc
+  )
+  {
+    const byte InitialChipSettings2 = 0b_00_0_00000; // DAC: VDD; Output = 0
+
+    using var mcp2221A = Mcp2221AController.Create(
+      Mcp2221AControllerTests.CreatePseudoDevice(
+        chipSettings2: InitialChipSettings2
+      ),
+      shouldDisposeUsbHidDevice: true
+    );
+
+    // command should not be sent
+    // Mcp2221AControllerTests.AppendPseudoResponse(...);
+    Mcp2221AControllerTests.ClearSentCommands(mcp2221A);
+
+    Assert.That(
+      async () => await writeAnalogVoltageAsyncFunc(mcp2221A.GpPins, voltage, referenceVoltage),
+      throwsArgumentExceptionConstraint
+    );
+
+    Assert.That(
+      Mcp2221AControllerTests.GetEndPointWriteStream(mcp2221A).Length,
+      Is.Zero,
+      "command should not be sent"
+    );
   }
 }

--- a/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221AController.cs
+++ b/tests/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/Mcp2221AController.cs
@@ -42,6 +42,7 @@ public partial class Mcp2221AControllerTests {
     byte gp1Settings = 0b_000_1_0_011, // Output: HIGH, Alternate Function 1 (LED UART TX)
     byte gp2Settings = 0b_000_1_0_001, // Output: HIGH, Dedicated function operation (USBCFG)
     byte gp3Settings = 0b_000_1_0_001, // Output: HIGH, Dedicated function operation (LED I2C)
+    byte chipSettings2 = 0b_00_0_00000, // DACVRM(7-6): VRM is OFF, DACREF(5): VDD, DACVAL(4-0): 0
     byte chipSettings3 = 0b_0_0_0_00_0_00 // INTDETFEEN(6): Disable, INTDETREEN(5): Disable, ADCVRM(4-3): VRM is off, ADCREF(2): VDD
   )
     => new(
@@ -173,7 +174,7 @@ public partial class Mcp2221AControllerTests {
             ReportInput,
             0x61, 0x00,
             0x00, 0x00,
-            0x00, 0x00, 0x00, chipSettings3,
+            0x00, 0x00, chipSettings2, chipSettings3,
             vendorIdHigh, vendorIdLow, productIdHigh, productIdLow,
             0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
### Description
This PR introduces support for DAC (Digital-to-Analog Converter) outputs for the MCP2221A.
The implementation focuses on providing both low-level raw values and high-level voltage conversion with a focus on API consistency.

#### Key Changes and Features
- **New `IDacController` Interface**: Introduced a dedicated interface for per-pin DAC control. It allows configuring the DAC-specific voltage reference and setting 5-bit raw output values. To ensure API symmetry with `IAdcController`, it includes the `LastWriteAnalogRawValue` property to access the current cached output state.
- **Enhanced `IGpControllerGroup` Interface**: Added `ApplyDacRawValue` and its asynchronous counterpart to update the DAC module's output. These methods provide a streamlined way to manage DAC operations alongside other GP functions in a single group context.
- **Voltage Conversion Extensions**: Implemented `WriteAnalogVoltage` extension methods for `IGpControllerGroup`. These methods allow users to specify target voltages [V] directly. The conversion logic accounts for the current VRM configuration or an explicitly provided reference voltage (e.g., measured VDD).
- **Predictable Quantization Logic**: Integrated a conversion utility that uses `Math.Round` with `MidpointRounding.AwayFromZero` to minimize quantization errors. The implementation is designed to be resilient against minor floating-point inaccuracies, ensuring the most accurate 5-bit representation for a given target voltage.

### Fixes issue
This PR will close #4.