### PR TITLE
I2C Read: Increment `totalReadLength` correctly

### DIFF
--- a/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.I2c/Mcp2221AI2cBus.ReadWrite.cs
+++ b/src/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A.Peripherals.I2c/Mcp2221AI2cBus.ReadWrite.cs
@@ -200,6 +200,8 @@ partial class Mcp2221AI2cBus {
 
           buffer = buffer.Slice(stateMachine.ReadLength);
 
+          totalReadLength += stateMachine.ReadLength;
+
           if (stateMachine.ReadLength < lengthToTransfer)
             break;
           if (buffer.IsEmpty)
@@ -279,6 +281,8 @@ partial class Mcp2221AI2cBus {
           readBufferMemory.Span.Slice(0, stateMachine.ReadLength).CopyTo(buffer);
 
           buffer = buffer.Slice(stateMachine.ReadLength);
+
+          totalReadLength += stateMachine.ReadLength;
 
           if (stateMachine.ReadLength < lengthToTransfer)
             break;


### PR DESCRIPTION
### Description
This PR fixes a bug in the I2C read operation methods where `totalReadLength` was not being counted, causing the methods to always return `0` regardless of the actual length read.

This fix also corrects the behavior of methods that determine results based on the actual length read.
For example, this resolves the issue where `ReadByte()` always returned `-1` and failed.

### Testing
Although no test cases have been added, the read operation on the BME280 and MCP23017 has been confirmed to work without issues.