### PR TITLE
Release main/Smdn.Devices.Mcp2221A-1.0.0-preview4

### DIFF
--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-net10.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-net10.0.apilist.cs
@@ -1,23 +1,25 @@
-// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview3)
+// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview4)
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview3+d42e385fe4b06f0ecfa89ea8ad4b2b176d8a4667
+//   InformationalVersion: 1.0.0-preview4+a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
 //   TargetFramework: .NETCoreApp,Version=v10.0
 //   Configuration: Release
 //   Metadata: IsTrimmable=True
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
-//   Metadata: RepositoryCommit=d42e385fe4b06f0ecfa89ea8ad4b2b176d8a4667
+//   Metadata: RepositoryCommit=a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.IO.UsbHid.Abstractions, Version=1.0.0.0, Culture=neutral
 //     System.Collections, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.ComponentModel.Primitives, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Device.Gpio, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
 //     System.Linq, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Memory, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Threading, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 #nullable enable annotations
 
 using System;
@@ -41,15 +43,40 @@ namespace Smdn.Devices.Mcp2221A {
     string SerialNumber { get; }
   }
 
+  public enum ClockOutputDutyCycle : int {
+    Duty0 = 0,
+    Duty25 = 1,
+    Duty50 = 2,
+    Duty75 = 3,
+  }
+
+  public enum ClockOutputFrequency : int {
+    Frequency12MHz = 2,
+    Frequency1500kHz = 5,
+    Frequency24MHz = 1,
+    Frequency375kHz = 7,
+    Frequency3MHz = 4,
+    Frequency6MHz = 3,
+    Frequency750kHz = 6,
+    Reserved = 0,
+  }
+
   public enum GpFunction : int {
     Adc = 1,
     ClockOutput = 5,
     Dac = 2,
-    ExternalInterrupt = 3,
     Gpio = 0,
+    InterruptOnChange = 3,
     LedOutput = 4,
     UsbConfigureStatus = 7,
     UsbSuspendStatus = 6,
+  }
+
+  public enum InterruptOnChangeTrigger : int {
+    Both = 3,
+    Falling = 2,
+    None = 0,
+    Rising = 1,
   }
 
   public enum VoltageReferenceSource : int {
@@ -58,6 +85,17 @@ namespace Smdn.Devices.Mcp2221A {
     Vrm2048 = 5,
     Vrm4096 = 7,
     VrmOff = 1,
+  }
+
+  public static class IClockOutputControllerExtensions {
+    extension(IClockOutputController controller) {
+      public int CurrentClockOutputDutyCycleInPercent { get; }
+      public double CurrentClockOutputDutyRatio { get; }
+      public int CurrentClockOutputFrequencyInHz { get; }
+
+      public void ResumeClockOutput(CancellationToken cancellationToken = default) {}
+      public ValueTask ResumeClockOutputAsync(CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class IGpControllerGroupExtensions {
@@ -92,32 +130,38 @@ namespace Smdn.Devices.Mcp2221A {
   }
 
   public static class IGpioControllerExtensions {
-    public static void ConfigureAsGpioInput(this IGpioController controller, CancellationToken cancellationToken = default) {}
-    public static ValueTask ConfigureAsGpioInputAsync(this IGpioController controller, CancellationToken cancellationToken = default) {}
-    public static void ConfigureAsGpioOutput(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-    public static ValueTask ConfigureAsGpioOutputAsync(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    extension(IGpioController controller) {
+      public void ConfigureAsGpioInput(CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAsGpioInputAsync(CancellationToken cancellationToken = default) {}
+      public void ConfigureAsGpioOutput(PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAsGpioOutputAsync(PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class II2cControllerExtensions {
-    public static int Read(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static int ReadByte(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
-    public static async ValueTask<int> ReadByteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
-    public static void Write(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static void WriteByte(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
-    public static async ValueTask WriteByteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+    extension(II2cController controller) {
+      public int Read(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadAsync(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public int ReadByte(I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadByteAsync(I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
+      public void Write(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public void WriteByte(I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteByteAsync(I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class II2cDeviceExtensions {
-    public static void Read(this II2cDevice device, Span<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadAsync(this II2cDevice device, Memory<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static int ReadByte(this II2cDevice device, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadByteAsync(this II2cDevice device, CancellationToken cancellationToken = default) {}
-    public static void Write(this II2cDevice device, ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteAsync(this II2cDevice device, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static void WriteByte(this II2cDevice device, byte @value, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteByteAsync(this II2cDevice device, byte @value, CancellationToken cancellationToken = default) {}
+    extension(II2cDevice device) {
+      public void Read(Span<byte> buffer, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
+      public int ReadByte(CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadByteAsync(CancellationToken cancellationToken = default) {}
+      public void Write(ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
+      public void WriteByte(byte @value, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteByteAsync(byte @value, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class IMcp2221AInfoExtensions {
@@ -132,7 +176,17 @@ namespace Smdn.Devices.Mcp2221A {
     public Mcp2221ACommandException(string? message, Exception? innerException) {}
   }
 
-  public class Mcp2221AController :
+  public class Mcp2221AConfigurationException : InvalidOperationException {
+    public Mcp2221AConfigurationException() {}
+    public Mcp2221AConfigurationException(string? message) {}
+    public Mcp2221AConfigurationException(string? message, Exception? innerException) {}
+
+    public GpFunction? CurrentFunction { get; }
+    public int? GpIndex { get; }
+    public GpFunction? RequiredFunction { get; }
+  }
+
+  public sealed class Mcp2221AController :
     IAsyncDisposable,
     IDisposable,
     IMcp2221AInfo
@@ -175,23 +229,10 @@ namespace Smdn.Devices.Mcp2221A {
     public string Product { get; }
     public string SerialNumber { get; }
 
-    protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
-    protected virtual async ValueTask DisposeAsyncCore() {}
     public void Reset(CancellationToken cancellationToken = default) {}
     public async ValueTask ResetAsync(CancellationToken cancellationToken = default) {}
-    private TResponse Smdn.Devices.Mcp2221A.IMcp2221ATransceiver.Command<TArg, TResponse>(ReadOnlySpan<byte> commandInput, Span<byte> responseOutput, TArg arg, Mcp2221AConstructCommandWithSpanAction<TArg> constructCommand, Mcp2221AParseResponseWithSpanFunc<TArg, TResponse> parseResponse, CancellationToken cancellationToken) {}
-    private ValueTask<TResponse> Smdn.Devices.Mcp2221A.IMcp2221ATransceiver.CommandAsync<TArg, TResponse>(ReadOnlyMemory<byte> commandInput, Memory<byte> responseOutput, TArg arg, Mcp2221AConstructCommandWithSpanAction<TArg> constructCommand, Mcp2221AParseResponseWithSpanFunc<TArg, TResponse> parseResponse, CancellationToken cancellationToken) {}
-  }
-
-  public sealed class Mcp2221AInfo : IMcp2221AInfo {
-    public string ChipFactorySerialNumber { get; init; }
-    public string FirmwareRevision { get; init; }
-    public string HardwareRevision { get; init; }
-    public string Manufacturer { get; init; }
-    public string Product { get; init; }
-    public string SerialNumber { get; init; }
   }
 
   public class Mcp2221ANotFoundException : InvalidOperationException {
@@ -219,9 +260,9 @@ namespace Smdn.Devices.Mcp2221A {
     IEquatable<byte>,
     IEquatable<int>
   {
-    public static readonly I2cAddress DeviceMaxValue; // = "77"
-    public static readonly I2cAddress DeviceMinValue; // = "08"
-    public static readonly I2cAddress Zero; // = "00"
+    public static I2cAddress DeviceMaxValue { get; } // = "0x77"
+    public static I2cAddress DeviceMinValue { get; } // = "0x08"
+    public static I2cAddress Zero { get; } // = "0x00"
 
     public static I2cAddress FromByte(byte address) {}
     public static bool operator == (I2cAddress x, I2cAddress y) {}
@@ -266,18 +307,28 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource CurrentAdcReferenceSource { get; }
     int LastReadAnalogRawValue { get; }
 
-    void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource, CancellationToken cancellationToken = default);
+    void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource, CancellationToken cancellationToken = default);
     int ReadAnalogRaw(CancellationToken cancellationToken = default);
     ValueTask<int> ReadAnalogRawAsync(CancellationToken cancellationToken = default);
+  }
+
+  public interface IClockOutputController {
+    ClockOutputDutyCycle CurrentClockOutputDutyCycle { get; }
+    ClockOutputFrequency CurrentClockOutputFrequency { get; }
+
+    void ConfigureAsClockOutput(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsClockOutputAsync(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default);
+    void SuspendClockOutput(CancellationToken cancellationToken = default);
+    ValueTask SuspendClockOutputAsync(CancellationToken cancellationToken = default);
   }
 
   public interface IDacController {
     VoltageReferenceSource CurrentDacReferenceSource { get; }
     int LastWriteAnalogRawValue { get; }
 
-    void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
+    void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
     void WriteAnalogRaw(int @value, CancellationToken cancellationToken = default);
     ValueTask WriteAnalogRawAsync(int @value, CancellationToken cancellationToken = default);
   }
@@ -303,8 +354,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public interface IGpioController {
-    void ConfigureAsGpio(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsGpioAsync(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
+    void ConfigureAsGpio(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsGpioAsync(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     PinMode GetMode(CancellationToken cancellationToken = default);
     ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default);
     PinValue Read(CancellationToken cancellationToken = default);
@@ -313,6 +364,18 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default);
     void Write(PinValue @value, CancellationToken cancellationToken = default);
     ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default);
+  }
+
+  public interface IInterruptOnChangeController {
+    InterruptOnChangeTrigger CurrentInterruptOnChangeTrigger { get; }
+    bool LastReadInterruptDetectionFlag { get; }
+
+    void ClearInterruptDetection(CancellationToken cancellationToken = default);
+    ValueTask ClearInterruptDetectionAsync(CancellationToken cancellationToken = default);
+    void ConfigureAsInterruptOnChange(InterruptOnChangeTrigger? detectionTrigger, bool clearDetectionFlag, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsInterruptOnChangeAsync(InterruptOnChangeTrigger? detectionTrigger, bool clearDetectionFlag, CancellationToken cancellationToken = default);
+    bool ReadInterruptDetection(CancellationToken cancellationToken = default);
+    ValueTask<bool> ReadInterruptDetectionAsync(CancellationToken cancellationToken = default);
   }
 
   public sealed class Gp0Controller : GpController {
@@ -329,25 +392,37 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
 
   public sealed class Gp1Controller :
     GpController,
-    IAdcController
+    IAdcController,
+    IClockOutputController,
+    IInterruptOnChangeController
   {
+    public ClockOutputDutyCycle CurrentClockOutputDutyCycle { get; }
+    public ClockOutputFrequency CurrentClockOutputFrequency { get; }
     public override string CurrentDesignation { get; }
     public override GpFunction CurrentFunction { get; }
+    public InterruptOnChangeTrigger CurrentInterruptOnChangeTrigger { get; }
     public override int Index { get; }
     public int LastReadAnalogRawValue { get; }
+    public bool LastReadInterruptDetectionFlag { get; }
     public override string PinName { get; }
     VoltageReferenceSource IAdcController.CurrentAdcReferenceSource { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsClockOutput(CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsClockOutputAsync(CancellationToken cancellationToken = default) {}
-    public void ConfigureAsExternalInterrupt(CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsExternalInterruptAsync(CancellationToken cancellationToken = default) {}
+    public void ClearInterruptDetection(CancellationToken cancellationToken = default) {}
+    public ValueTask ClearInterruptDetectionAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsClockOutput(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsClockOutputAsync(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsInterruptOnChange(InterruptOnChangeTrigger? detectionTrigger = null, bool clearDetectionFlag = true, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsInterruptOnChangeAsync(InterruptOnChangeTrigger? detectionTrigger = null, bool clearDetectionFlag = true, CancellationToken cancellationToken = default) {}
     public void ConfigureAsUtxLedOutput(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsUtxLedOutputAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
     public async ValueTask<int> ReadAnalogRawAsync(CancellationToken cancellationToken = default) {}
+    public bool ReadInterruptDetection(CancellationToken cancellationToken = default) {}
+    public async ValueTask<bool> ReadInterruptDetectionAsync(CancellationToken cancellationToken = default) {}
+    public void SuspendClockOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask SuspendClockOutputAsync(CancellationToken cancellationToken = default) {}
   }
 
   public sealed class Gp2Controller :
@@ -364,10 +439,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource IDacController.CurrentDacReferenceSource { get; }
     int IDacController.LastWriteAnalogRawValue { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
     public void ConfigureAsUsbConfigureStatus(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsUsbConfigureStatusAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
@@ -390,10 +465,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource IDacController.CurrentDacReferenceSource { get; }
     int IDacController.LastWriteAnalogRawValue { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
     public void ConfigureAsI2cLedOutput(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsI2cLedOutputAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
@@ -411,8 +486,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     public PinValue LastUpdatedValue { get; }
     public abstract string PinName { get; }
 
-    public void ConfigureAsGpio(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsGpioAsync(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsGpio(PinMode? mode = (PinMode)1, PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsGpioAsync(PinMode? mode = (PinMode)1, PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
     public PinMode GetMode(CancellationToken cancellationToken = default) {}
     public async ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default) {}
     public bool IsFunctionSupported(GpFunction function) {}
@@ -483,8 +558,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
   }
 
   public static class II2cControllerBusScanningExtensions {
-    public static (IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet) ScanBus(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
-    public static async ValueTask<(IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet)> ScanBusAsync(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+    extension(II2cController controller) {
+      public (IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet) ScanBus(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public ValueTask<(IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public sealed class Mcp2221AI2cBus :

--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-net8.0.apilist.cs
@@ -1,23 +1,25 @@
-// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview3)
+// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview4)
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview3+d42e385fe4b06f0ecfa89ea8ad4b2b176d8a4667
+//   InformationalVersion: 1.0.0-preview4+a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Metadata: IsTrimmable=True
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
-//   Metadata: RepositoryCommit=d42e385fe4b06f0ecfa89ea8ad4b2b176d8a4667
+//   Metadata: RepositoryCommit=a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.IO.UsbHid.Abstractions, Version=1.0.0.0, Culture=neutral
 //     System.Collections, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.ComponentModel.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Device.Gpio, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
 //     System.Linq, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Memory, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Threading, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 #nullable enable annotations
 
 using System;
@@ -41,15 +43,40 @@ namespace Smdn.Devices.Mcp2221A {
     string SerialNumber { get; }
   }
 
+  public enum ClockOutputDutyCycle : int {
+    Duty0 = 0,
+    Duty25 = 1,
+    Duty50 = 2,
+    Duty75 = 3,
+  }
+
+  public enum ClockOutputFrequency : int {
+    Frequency12MHz = 2,
+    Frequency1500kHz = 5,
+    Frequency24MHz = 1,
+    Frequency375kHz = 7,
+    Frequency3MHz = 4,
+    Frequency6MHz = 3,
+    Frequency750kHz = 6,
+    Reserved = 0,
+  }
+
   public enum GpFunction : int {
     Adc = 1,
     ClockOutput = 5,
     Dac = 2,
-    ExternalInterrupt = 3,
     Gpio = 0,
+    InterruptOnChange = 3,
     LedOutput = 4,
     UsbConfigureStatus = 7,
     UsbSuspendStatus = 6,
+  }
+
+  public enum InterruptOnChangeTrigger : int {
+    Both = 3,
+    Falling = 2,
+    None = 0,
+    Rising = 1,
   }
 
   public enum VoltageReferenceSource : int {
@@ -58,6 +85,17 @@ namespace Smdn.Devices.Mcp2221A {
     Vrm2048 = 5,
     Vrm4096 = 7,
     VrmOff = 1,
+  }
+
+  public static class IClockOutputControllerExtensions {
+    extension(IClockOutputController controller) {
+      public int CurrentClockOutputDutyCycleInPercent { get; }
+      public double CurrentClockOutputDutyRatio { get; }
+      public int CurrentClockOutputFrequencyInHz { get; }
+
+      public void ResumeClockOutput(CancellationToken cancellationToken = default) {}
+      public ValueTask ResumeClockOutputAsync(CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class IGpControllerGroupExtensions {
@@ -92,32 +130,38 @@ namespace Smdn.Devices.Mcp2221A {
   }
 
   public static class IGpioControllerExtensions {
-    public static void ConfigureAsGpioInput(this IGpioController controller, CancellationToken cancellationToken = default) {}
-    public static ValueTask ConfigureAsGpioInputAsync(this IGpioController controller, CancellationToken cancellationToken = default) {}
-    public static void ConfigureAsGpioOutput(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-    public static ValueTask ConfigureAsGpioOutputAsync(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    extension(IGpioController controller) {
+      public void ConfigureAsGpioInput(CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAsGpioInputAsync(CancellationToken cancellationToken = default) {}
+      public void ConfigureAsGpioOutput(PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAsGpioOutputAsync(PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class II2cControllerExtensions {
-    public static int Read(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static int ReadByte(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
-    public static async ValueTask<int> ReadByteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
-    public static void Write(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static void WriteByte(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
-    public static async ValueTask WriteByteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+    extension(II2cController controller) {
+      public int Read(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadAsync(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public int ReadByte(I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadByteAsync(I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
+      public void Write(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public void WriteByte(I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteByteAsync(I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class II2cDeviceExtensions {
-    public static void Read(this II2cDevice device, Span<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadAsync(this II2cDevice device, Memory<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static int ReadByte(this II2cDevice device, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadByteAsync(this II2cDevice device, CancellationToken cancellationToken = default) {}
-    public static void Write(this II2cDevice device, ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteAsync(this II2cDevice device, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static void WriteByte(this II2cDevice device, byte @value, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteByteAsync(this II2cDevice device, byte @value, CancellationToken cancellationToken = default) {}
+    extension(II2cDevice device) {
+      public void Read(Span<byte> buffer, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
+      public int ReadByte(CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadByteAsync(CancellationToken cancellationToken = default) {}
+      public void Write(ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
+      public void WriteByte(byte @value, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteByteAsync(byte @value, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class IMcp2221AInfoExtensions {
@@ -132,7 +176,17 @@ namespace Smdn.Devices.Mcp2221A {
     public Mcp2221ACommandException(string? message, Exception? innerException) {}
   }
 
-  public class Mcp2221AController :
+  public class Mcp2221AConfigurationException : InvalidOperationException {
+    public Mcp2221AConfigurationException() {}
+    public Mcp2221AConfigurationException(string? message) {}
+    public Mcp2221AConfigurationException(string? message, Exception? innerException) {}
+
+    public GpFunction? CurrentFunction { get; }
+    public int? GpIndex { get; }
+    public GpFunction? RequiredFunction { get; }
+  }
+
+  public sealed class Mcp2221AController :
     IAsyncDisposable,
     IDisposable,
     IMcp2221AInfo
@@ -175,23 +229,10 @@ namespace Smdn.Devices.Mcp2221A {
     public string Product { get; }
     public string SerialNumber { get; }
 
-    protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
-    protected virtual async ValueTask DisposeAsyncCore() {}
     public void Reset(CancellationToken cancellationToken = default) {}
     public async ValueTask ResetAsync(CancellationToken cancellationToken = default) {}
-    private TResponse Smdn.Devices.Mcp2221A.IMcp2221ATransceiver.Command<TArg, TResponse>(ReadOnlySpan<byte> commandInput, Span<byte> responseOutput, TArg arg, Mcp2221AConstructCommandWithSpanAction<TArg> constructCommand, Mcp2221AParseResponseWithSpanFunc<TArg, TResponse> parseResponse, CancellationToken cancellationToken) {}
-    private ValueTask<TResponse> Smdn.Devices.Mcp2221A.IMcp2221ATransceiver.CommandAsync<TArg, TResponse>(ReadOnlyMemory<byte> commandInput, Memory<byte> responseOutput, TArg arg, Mcp2221AConstructCommandWithSpanAction<TArg> constructCommand, Mcp2221AParseResponseWithSpanFunc<TArg, TResponse> parseResponse, CancellationToken cancellationToken) {}
-  }
-
-  public sealed class Mcp2221AInfo : IMcp2221AInfo {
-    public string ChipFactorySerialNumber { get; init; }
-    public string FirmwareRevision { get; init; }
-    public string HardwareRevision { get; init; }
-    public string Manufacturer { get; init; }
-    public string Product { get; init; }
-    public string SerialNumber { get; init; }
   }
 
   public class Mcp2221ANotFoundException : InvalidOperationException {
@@ -219,9 +260,9 @@ namespace Smdn.Devices.Mcp2221A {
     IEquatable<byte>,
     IEquatable<int>
   {
-    public static readonly I2cAddress DeviceMaxValue; // = "77"
-    public static readonly I2cAddress DeviceMinValue; // = "08"
-    public static readonly I2cAddress Zero; // = "00"
+    public static I2cAddress DeviceMaxValue { get; } // = "0x77"
+    public static I2cAddress DeviceMinValue { get; } // = "0x08"
+    public static I2cAddress Zero { get; } // = "0x00"
 
     public static I2cAddress FromByte(byte address) {}
     public static bool operator == (I2cAddress x, I2cAddress y) {}
@@ -266,18 +307,28 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource CurrentAdcReferenceSource { get; }
     int LastReadAnalogRawValue { get; }
 
-    void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource, CancellationToken cancellationToken = default);
+    void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource, CancellationToken cancellationToken = default);
     int ReadAnalogRaw(CancellationToken cancellationToken = default);
     ValueTask<int> ReadAnalogRawAsync(CancellationToken cancellationToken = default);
+  }
+
+  public interface IClockOutputController {
+    ClockOutputDutyCycle CurrentClockOutputDutyCycle { get; }
+    ClockOutputFrequency CurrentClockOutputFrequency { get; }
+
+    void ConfigureAsClockOutput(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsClockOutputAsync(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default);
+    void SuspendClockOutput(CancellationToken cancellationToken = default);
+    ValueTask SuspendClockOutputAsync(CancellationToken cancellationToken = default);
   }
 
   public interface IDacController {
     VoltageReferenceSource CurrentDacReferenceSource { get; }
     int LastWriteAnalogRawValue { get; }
 
-    void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
+    void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
     void WriteAnalogRaw(int @value, CancellationToken cancellationToken = default);
     ValueTask WriteAnalogRawAsync(int @value, CancellationToken cancellationToken = default);
   }
@@ -303,8 +354,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public interface IGpioController {
-    void ConfigureAsGpio(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsGpioAsync(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
+    void ConfigureAsGpio(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsGpioAsync(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     PinMode GetMode(CancellationToken cancellationToken = default);
     ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default);
     PinValue Read(CancellationToken cancellationToken = default);
@@ -313,6 +364,18 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default);
     void Write(PinValue @value, CancellationToken cancellationToken = default);
     ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default);
+  }
+
+  public interface IInterruptOnChangeController {
+    InterruptOnChangeTrigger CurrentInterruptOnChangeTrigger { get; }
+    bool LastReadInterruptDetectionFlag { get; }
+
+    void ClearInterruptDetection(CancellationToken cancellationToken = default);
+    ValueTask ClearInterruptDetectionAsync(CancellationToken cancellationToken = default);
+    void ConfigureAsInterruptOnChange(InterruptOnChangeTrigger? detectionTrigger, bool clearDetectionFlag, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsInterruptOnChangeAsync(InterruptOnChangeTrigger? detectionTrigger, bool clearDetectionFlag, CancellationToken cancellationToken = default);
+    bool ReadInterruptDetection(CancellationToken cancellationToken = default);
+    ValueTask<bool> ReadInterruptDetectionAsync(CancellationToken cancellationToken = default);
   }
 
   public sealed class Gp0Controller : GpController {
@@ -329,25 +392,37 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
 
   public sealed class Gp1Controller :
     GpController,
-    IAdcController
+    IAdcController,
+    IClockOutputController,
+    IInterruptOnChangeController
   {
+    public ClockOutputDutyCycle CurrentClockOutputDutyCycle { get; }
+    public ClockOutputFrequency CurrentClockOutputFrequency { get; }
     public override string CurrentDesignation { get; }
     public override GpFunction CurrentFunction { get; }
+    public InterruptOnChangeTrigger CurrentInterruptOnChangeTrigger { get; }
     public override int Index { get; }
     public int LastReadAnalogRawValue { get; }
+    public bool LastReadInterruptDetectionFlag { get; }
     public override string PinName { get; }
     VoltageReferenceSource IAdcController.CurrentAdcReferenceSource { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsClockOutput(CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsClockOutputAsync(CancellationToken cancellationToken = default) {}
-    public void ConfigureAsExternalInterrupt(CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsExternalInterruptAsync(CancellationToken cancellationToken = default) {}
+    public void ClearInterruptDetection(CancellationToken cancellationToken = default) {}
+    public ValueTask ClearInterruptDetectionAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsClockOutput(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsClockOutputAsync(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsInterruptOnChange(InterruptOnChangeTrigger? detectionTrigger = null, bool clearDetectionFlag = true, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsInterruptOnChangeAsync(InterruptOnChangeTrigger? detectionTrigger = null, bool clearDetectionFlag = true, CancellationToken cancellationToken = default) {}
     public void ConfigureAsUtxLedOutput(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsUtxLedOutputAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
     public async ValueTask<int> ReadAnalogRawAsync(CancellationToken cancellationToken = default) {}
+    public bool ReadInterruptDetection(CancellationToken cancellationToken = default) {}
+    public async ValueTask<bool> ReadInterruptDetectionAsync(CancellationToken cancellationToken = default) {}
+    public void SuspendClockOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask SuspendClockOutputAsync(CancellationToken cancellationToken = default) {}
   }
 
   public sealed class Gp2Controller :
@@ -364,10 +439,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource IDacController.CurrentDacReferenceSource { get; }
     int IDacController.LastWriteAnalogRawValue { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
     public void ConfigureAsUsbConfigureStatus(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsUsbConfigureStatusAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
@@ -390,10 +465,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource IDacController.CurrentDacReferenceSource { get; }
     int IDacController.LastWriteAnalogRawValue { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
     public void ConfigureAsI2cLedOutput(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsI2cLedOutputAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
@@ -411,8 +486,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     public PinValue LastUpdatedValue { get; }
     public abstract string PinName { get; }
 
-    public void ConfigureAsGpio(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsGpioAsync(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsGpio(PinMode? mode = (PinMode)1, PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsGpioAsync(PinMode? mode = (PinMode)1, PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
     public PinMode GetMode(CancellationToken cancellationToken = default) {}
     public async ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default) {}
     public bool IsFunctionSupported(GpFunction function) {}
@@ -483,8 +558,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
   }
 
   public static class II2cControllerBusScanningExtensions {
-    public static (IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet) ScanBus(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
-    public static async ValueTask<(IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet)> ScanBusAsync(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+    extension(II2cController controller) {
+      public (IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet) ScanBus(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public ValueTask<(IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public sealed class Mcp2221AI2cBus :

--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.0.apilist.cs
@@ -1,12 +1,12 @@
-// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview3)
+// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview4)
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview3+d42e385fe4b06f0ecfa89ea8ad4b2b176d8a4667
+//   InformationalVersion: 1.0.0-preview4+a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
-//   Metadata: RepositoryCommit=d42e385fe4b06f0ecfa89ea8ad4b2b176d8a4667
+//   Metadata: RepositoryCommit=a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
 //   Referenced assemblies:
 //     Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
@@ -40,15 +40,40 @@ namespace Smdn.Devices.Mcp2221A {
     string SerialNumber { get; }
   }
 
+  public enum ClockOutputDutyCycle : int {
+    Duty0 = 0,
+    Duty25 = 1,
+    Duty50 = 2,
+    Duty75 = 3,
+  }
+
+  public enum ClockOutputFrequency : int {
+    Frequency12MHz = 2,
+    Frequency1500kHz = 5,
+    Frequency24MHz = 1,
+    Frequency375kHz = 7,
+    Frequency3MHz = 4,
+    Frequency6MHz = 3,
+    Frequency750kHz = 6,
+    Reserved = 0,
+  }
+
   public enum GpFunction : int {
     Adc = 1,
     ClockOutput = 5,
     Dac = 2,
-    ExternalInterrupt = 3,
     Gpio = 0,
+    InterruptOnChange = 3,
     LedOutput = 4,
     UsbConfigureStatus = 7,
     UsbSuspendStatus = 6,
+  }
+
+  public enum InterruptOnChangeTrigger : int {
+    Both = 3,
+    Falling = 2,
+    None = 0,
+    Rising = 1,
   }
 
   public enum VoltageReferenceSource : int {
@@ -57,6 +82,17 @@ namespace Smdn.Devices.Mcp2221A {
     Vrm2048 = 5,
     Vrm4096 = 7,
     VrmOff = 1,
+  }
+
+  public static class IClockOutputControllerExtensions {
+    extension(IClockOutputController controller) {
+      public int CurrentClockOutputDutyCycleInPercent { get; }
+      public double CurrentClockOutputDutyRatio { get; }
+      public int CurrentClockOutputFrequencyInHz { get; }
+
+      public void ResumeClockOutput(CancellationToken cancellationToken = default) {}
+      public ValueTask ResumeClockOutputAsync(CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class IGpControllerGroupExtensions {
@@ -91,32 +127,38 @@ namespace Smdn.Devices.Mcp2221A {
   }
 
   public static class IGpioControllerExtensions {
-    public static void ConfigureAsGpioInput(this IGpioController controller, CancellationToken cancellationToken = default) {}
-    public static ValueTask ConfigureAsGpioInputAsync(this IGpioController controller, CancellationToken cancellationToken = default) {}
-    public static void ConfigureAsGpioOutput(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-    public static ValueTask ConfigureAsGpioOutputAsync(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    extension(IGpioController controller) {
+      public void ConfigureAsGpioInput(CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAsGpioInputAsync(CancellationToken cancellationToken = default) {}
+      public void ConfigureAsGpioOutput(PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAsGpioOutputAsync(PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class II2cControllerExtensions {
-    public static int Read(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static int ReadByte(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
-    public static async ValueTask<int> ReadByteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
-    public static void Write(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static void WriteByte(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
-    public static async ValueTask WriteByteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+    extension(II2cController controller) {
+      public int Read(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadAsync(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public int ReadByte(I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadByteAsync(I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
+      public void Write(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public void WriteByte(I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteByteAsync(I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class II2cDeviceExtensions {
-    public static void Read(this II2cDevice device, Span<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadAsync(this II2cDevice device, Memory<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static int ReadByte(this II2cDevice device, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadByteAsync(this II2cDevice device, CancellationToken cancellationToken = default) {}
-    public static void Write(this II2cDevice device, ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteAsync(this II2cDevice device, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static void WriteByte(this II2cDevice device, byte @value, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteByteAsync(this II2cDevice device, byte @value, CancellationToken cancellationToken = default) {}
+    extension(II2cDevice device) {
+      public void Read(Span<byte> buffer, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
+      public int ReadByte(CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadByteAsync(CancellationToken cancellationToken = default) {}
+      public void Write(ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
+      public void WriteByte(byte @value, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteByteAsync(byte @value, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class IMcp2221AInfoExtensions {
@@ -131,7 +173,17 @@ namespace Smdn.Devices.Mcp2221A {
     public Mcp2221ACommandException(string? message, Exception? innerException) {}
   }
 
-  public class Mcp2221AController :
+  public class Mcp2221AConfigurationException : InvalidOperationException {
+    public Mcp2221AConfigurationException() {}
+    public Mcp2221AConfigurationException(string? message) {}
+    public Mcp2221AConfigurationException(string? message, Exception? innerException) {}
+
+    public GpFunction? CurrentFunction { get; }
+    public int? GpIndex { get; }
+    public GpFunction? RequiredFunction { get; }
+  }
+
+  public sealed class Mcp2221AController :
     IAsyncDisposable,
     IDisposable,
     IMcp2221AInfo
@@ -174,23 +226,10 @@ namespace Smdn.Devices.Mcp2221A {
     public string Product { get; }
     public string SerialNumber { get; }
 
-    protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
-    protected virtual async ValueTask DisposeAsyncCore() {}
     public void Reset(CancellationToken cancellationToken = default) {}
     public async ValueTask ResetAsync(CancellationToken cancellationToken = default) {}
-    private TResponse Smdn.Devices.Mcp2221A.IMcp2221ATransceiver.Command<TArg, TResponse>(ReadOnlySpan<byte> commandInput, Span<byte> responseOutput, TArg arg, Mcp2221AConstructCommandWithSpanAction<TArg> constructCommand, Mcp2221AParseResponseWithSpanFunc<TArg, TResponse> parseResponse, CancellationToken cancellationToken) {}
-    private ValueTask<TResponse> Smdn.Devices.Mcp2221A.IMcp2221ATransceiver.CommandAsync<TArg, TResponse>(ReadOnlyMemory<byte> commandInput, Memory<byte> responseOutput, TArg arg, Mcp2221AConstructCommandWithSpanAction<TArg> constructCommand, Mcp2221AParseResponseWithSpanFunc<TArg, TResponse> parseResponse, CancellationToken cancellationToken) {}
-  }
-
-  public sealed class Mcp2221AInfo : IMcp2221AInfo {
-    public string ChipFactorySerialNumber { get; init; }
-    public string FirmwareRevision { get; init; }
-    public string HardwareRevision { get; init; }
-    public string Manufacturer { get; init; }
-    public string Product { get; init; }
-    public string SerialNumber { get; init; }
   }
 
   public class Mcp2221ANotFoundException : InvalidOperationException {
@@ -218,9 +257,9 @@ namespace Smdn.Devices.Mcp2221A {
     IEquatable<byte>,
     IEquatable<int>
   {
-    public static readonly I2cAddress DeviceMaxValue; // = "77"
-    public static readonly I2cAddress DeviceMinValue; // = "08"
-    public static readonly I2cAddress Zero; // = "00"
+    public static I2cAddress DeviceMaxValue { get; } // = "0x77"
+    public static I2cAddress DeviceMinValue { get; } // = "0x08"
+    public static I2cAddress Zero { get; } // = "0x00"
 
     public static I2cAddress FromByte(byte address) {}
     public static bool operator == (I2cAddress x, I2cAddress y) {}
@@ -265,18 +304,28 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource CurrentAdcReferenceSource { get; }
     int LastReadAnalogRawValue { get; }
 
-    void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource, CancellationToken cancellationToken = default);
+    void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource, CancellationToken cancellationToken = default);
     int ReadAnalogRaw(CancellationToken cancellationToken = default);
     ValueTask<int> ReadAnalogRawAsync(CancellationToken cancellationToken = default);
+  }
+
+  public interface IClockOutputController {
+    ClockOutputDutyCycle CurrentClockOutputDutyCycle { get; }
+    ClockOutputFrequency CurrentClockOutputFrequency { get; }
+
+    void ConfigureAsClockOutput(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsClockOutputAsync(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default);
+    void SuspendClockOutput(CancellationToken cancellationToken = default);
+    ValueTask SuspendClockOutputAsync(CancellationToken cancellationToken = default);
   }
 
   public interface IDacController {
     VoltageReferenceSource CurrentDacReferenceSource { get; }
     int LastWriteAnalogRawValue { get; }
 
-    void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
+    void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
     void WriteAnalogRaw(int @value, CancellationToken cancellationToken = default);
     ValueTask WriteAnalogRawAsync(int @value, CancellationToken cancellationToken = default);
   }
@@ -302,8 +351,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public interface IGpioController {
-    void ConfigureAsGpio(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsGpioAsync(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
+    void ConfigureAsGpio(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsGpioAsync(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     PinMode GetMode(CancellationToken cancellationToken = default);
     ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default);
     PinValue Read(CancellationToken cancellationToken = default);
@@ -312,6 +361,18 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default);
     void Write(PinValue @value, CancellationToken cancellationToken = default);
     ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default);
+  }
+
+  public interface IInterruptOnChangeController {
+    InterruptOnChangeTrigger CurrentInterruptOnChangeTrigger { get; }
+    bool LastReadInterruptDetectionFlag { get; }
+
+    void ClearInterruptDetection(CancellationToken cancellationToken = default);
+    ValueTask ClearInterruptDetectionAsync(CancellationToken cancellationToken = default);
+    void ConfigureAsInterruptOnChange(InterruptOnChangeTrigger? detectionTrigger, bool clearDetectionFlag, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsInterruptOnChangeAsync(InterruptOnChangeTrigger? detectionTrigger, bool clearDetectionFlag, CancellationToken cancellationToken = default);
+    bool ReadInterruptDetection(CancellationToken cancellationToken = default);
+    ValueTask<bool> ReadInterruptDetectionAsync(CancellationToken cancellationToken = default);
   }
 
   public sealed class Gp0Controller : GpController {
@@ -328,25 +389,37 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
 
   public sealed class Gp1Controller :
     GpController,
-    IAdcController
+    IAdcController,
+    IClockOutputController,
+    IInterruptOnChangeController
   {
+    public ClockOutputDutyCycle CurrentClockOutputDutyCycle { get; }
+    public ClockOutputFrequency CurrentClockOutputFrequency { get; }
     public override string CurrentDesignation { get; }
     public override GpFunction CurrentFunction { get; }
+    public InterruptOnChangeTrigger CurrentInterruptOnChangeTrigger { get; }
     public override int Index { get; }
     public int LastReadAnalogRawValue { get; }
+    public bool LastReadInterruptDetectionFlag { get; }
     public override string PinName { get; }
     VoltageReferenceSource IAdcController.CurrentAdcReferenceSource { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsClockOutput(CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsClockOutputAsync(CancellationToken cancellationToken = default) {}
-    public void ConfigureAsExternalInterrupt(CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsExternalInterruptAsync(CancellationToken cancellationToken = default) {}
+    public void ClearInterruptDetection(CancellationToken cancellationToken = default) {}
+    public ValueTask ClearInterruptDetectionAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsClockOutput(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsClockOutputAsync(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsInterruptOnChange(InterruptOnChangeTrigger? detectionTrigger = null, bool clearDetectionFlag = true, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsInterruptOnChangeAsync(InterruptOnChangeTrigger? detectionTrigger = null, bool clearDetectionFlag = true, CancellationToken cancellationToken = default) {}
     public void ConfigureAsUtxLedOutput(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsUtxLedOutputAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
     public async ValueTask<int> ReadAnalogRawAsync(CancellationToken cancellationToken = default) {}
+    public bool ReadInterruptDetection(CancellationToken cancellationToken = default) {}
+    public async ValueTask<bool> ReadInterruptDetectionAsync(CancellationToken cancellationToken = default) {}
+    public void SuspendClockOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask SuspendClockOutputAsync(CancellationToken cancellationToken = default) {}
   }
 
   public sealed class Gp2Controller :
@@ -363,10 +436,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource IDacController.CurrentDacReferenceSource { get; }
     int IDacController.LastWriteAnalogRawValue { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
     public void ConfigureAsUsbConfigureStatus(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsUsbConfigureStatusAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
@@ -389,10 +462,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource IDacController.CurrentDacReferenceSource { get; }
     int IDacController.LastWriteAnalogRawValue { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
     public void ConfigureAsI2cLedOutput(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsI2cLedOutputAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
@@ -410,8 +483,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     public PinValue LastUpdatedValue { get; }
     public abstract string PinName { get; }
 
-    public void ConfigureAsGpio(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsGpioAsync(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsGpio(PinMode? mode = (PinMode)1, PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsGpioAsync(PinMode? mode = (PinMode)1, PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
     public PinMode GetMode(CancellationToken cancellationToken = default) {}
     public async ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default) {}
     public bool IsFunctionSupported(GpFunction function) {}
@@ -482,8 +555,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
   }
 
   public static class II2cControllerBusScanningExtensions {
-    public static (IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet) ScanBus(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
-    public static async ValueTask<(IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet)> ScanBusAsync(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+    extension(II2cController controller) {
+      public (IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet) ScanBus(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public ValueTask<(IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public sealed class Mcp2221AI2cBus :

--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.1.apilist.cs
@@ -1,12 +1,12 @@
-// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview3)
+// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview4)
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview3+d42e385fe4b06f0ecfa89ea8ad4b2b176d8a4667
+//   InformationalVersion: 1.0.0-preview4+a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
-//   Metadata: RepositoryCommit=d42e385fe4b06f0ecfa89ea8ad4b2b176d8a4667
+//   Metadata: RepositoryCommit=a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
@@ -36,15 +36,40 @@ namespace Smdn.Devices.Mcp2221A {
     string SerialNumber { get; }
   }
 
+  public enum ClockOutputDutyCycle : int {
+    Duty0 = 0,
+    Duty25 = 1,
+    Duty50 = 2,
+    Duty75 = 3,
+  }
+
+  public enum ClockOutputFrequency : int {
+    Frequency12MHz = 2,
+    Frequency1500kHz = 5,
+    Frequency24MHz = 1,
+    Frequency375kHz = 7,
+    Frequency3MHz = 4,
+    Frequency6MHz = 3,
+    Frequency750kHz = 6,
+    Reserved = 0,
+  }
+
   public enum GpFunction : int {
     Adc = 1,
     ClockOutput = 5,
     Dac = 2,
-    ExternalInterrupt = 3,
     Gpio = 0,
+    InterruptOnChange = 3,
     LedOutput = 4,
     UsbConfigureStatus = 7,
     UsbSuspendStatus = 6,
+  }
+
+  public enum InterruptOnChangeTrigger : int {
+    Both = 3,
+    Falling = 2,
+    None = 0,
+    Rising = 1,
   }
 
   public enum VoltageReferenceSource : int {
@@ -53,6 +78,17 @@ namespace Smdn.Devices.Mcp2221A {
     Vrm2048 = 5,
     Vrm4096 = 7,
     VrmOff = 1,
+  }
+
+  public static class IClockOutputControllerExtensions {
+    extension(IClockOutputController controller) {
+      public int CurrentClockOutputDutyCycleInPercent { get; }
+      public double CurrentClockOutputDutyRatio { get; }
+      public int CurrentClockOutputFrequencyInHz { get; }
+
+      public void ResumeClockOutput(CancellationToken cancellationToken = default) {}
+      public ValueTask ResumeClockOutputAsync(CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class IGpControllerGroupExtensions {
@@ -87,32 +123,38 @@ namespace Smdn.Devices.Mcp2221A {
   }
 
   public static class IGpioControllerExtensions {
-    public static void ConfigureAsGpioInput(this IGpioController controller, CancellationToken cancellationToken = default) {}
-    public static ValueTask ConfigureAsGpioInputAsync(this IGpioController controller, CancellationToken cancellationToken = default) {}
-    public static void ConfigureAsGpioOutput(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-    public static ValueTask ConfigureAsGpioOutputAsync(this IGpioController controller, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    extension(IGpioController controller) {
+      public void ConfigureAsGpioInput(CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAsGpioInputAsync(CancellationToken cancellationToken = default) {}
+      public void ConfigureAsGpioOutput(PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+      public ValueTask ConfigureAsGpioOutputAsync(PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class II2cControllerExtensions {
-    public static int Read(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static int ReadByte(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
-    public static async ValueTask<int> ReadByteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
-    public static void Write(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
-    public static void WriteByte(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
-    public static async ValueTask WriteByteAsync(this II2cController controller, I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+    extension(II2cController controller) {
+      public int Read(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadAsync(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public int ReadByte(I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadByteAsync(I2cAddress address, int transmissionSpeedInKbps, CancellationToken cancellationToken = default) {}
+      public void Write(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(I2cAddress address, int transmissionSpeedInKbps, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+      public void WriteByte(I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteByteAsync(I2cAddress address, int transmissionSpeedInKbps, byte @value, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class II2cDeviceExtensions {
-    public static void Read(this II2cDevice device, Span<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadAsync(this II2cDevice device, Memory<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static int ReadByte(this II2cDevice device, CancellationToken cancellationToken = default) {}
-    public static ValueTask<int> ReadByteAsync(this II2cDevice device, CancellationToken cancellationToken = default) {}
-    public static void Write(this II2cDevice device, ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteAsync(this II2cDevice device, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
-    public static void WriteByte(this II2cDevice device, byte @value, CancellationToken cancellationToken = default) {}
-    public static ValueTask WriteByteAsync(this II2cDevice device, byte @value, CancellationToken cancellationToken = default) {}
+    extension(II2cDevice device) {
+      public void Read(Span<byte> buffer, CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
+      public int ReadByte(CancellationToken cancellationToken = default) {}
+      public ValueTask<int> ReadByteAsync(CancellationToken cancellationToken = default) {}
+      public void Write(ReadOnlySpan<byte> buffer, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
+      public void WriteByte(byte @value, CancellationToken cancellationToken = default) {}
+      public ValueTask WriteByteAsync(byte @value, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public static class IMcp2221AInfoExtensions {
@@ -127,7 +169,17 @@ namespace Smdn.Devices.Mcp2221A {
     public Mcp2221ACommandException(string? message, Exception? innerException) {}
   }
 
-  public class Mcp2221AController :
+  public class Mcp2221AConfigurationException : InvalidOperationException {
+    public Mcp2221AConfigurationException() {}
+    public Mcp2221AConfigurationException(string? message) {}
+    public Mcp2221AConfigurationException(string? message, Exception? innerException) {}
+
+    public GpFunction? CurrentFunction { get; }
+    public int? GpIndex { get; }
+    public GpFunction? RequiredFunction { get; }
+  }
+
+  public sealed class Mcp2221AController :
     IAsyncDisposable,
     IDisposable,
     IMcp2221AInfo
@@ -170,23 +222,10 @@ namespace Smdn.Devices.Mcp2221A {
     public string Product { get; }
     public string SerialNumber { get; }
 
-    protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
-    protected virtual async ValueTask DisposeAsyncCore() {}
     public void Reset(CancellationToken cancellationToken = default) {}
     public async ValueTask ResetAsync(CancellationToken cancellationToken = default) {}
-    private TResponse Smdn.Devices.Mcp2221A.IMcp2221ATransceiver.Command<TArg, TResponse>(ReadOnlySpan<byte> commandInput, Span<byte> responseOutput, TArg arg, Mcp2221AConstructCommandWithSpanAction<TArg> constructCommand, Mcp2221AParseResponseWithSpanFunc<TArg, TResponse> parseResponse, CancellationToken cancellationToken) {}
-    private ValueTask<TResponse> Smdn.Devices.Mcp2221A.IMcp2221ATransceiver.CommandAsync<TArg, TResponse>(ReadOnlyMemory<byte> commandInput, Memory<byte> responseOutput, TArg arg, Mcp2221AConstructCommandWithSpanAction<TArg> constructCommand, Mcp2221AParseResponseWithSpanFunc<TArg, TResponse> parseResponse, CancellationToken cancellationToken) {}
-  }
-
-  public sealed class Mcp2221AInfo : IMcp2221AInfo {
-    public string ChipFactorySerialNumber { get; init; }
-    public string FirmwareRevision { get; init; }
-    public string HardwareRevision { get; init; }
-    public string Manufacturer { get; init; }
-    public string Product { get; init; }
-    public string SerialNumber { get; init; }
   }
 
   public class Mcp2221ANotFoundException : InvalidOperationException {
@@ -214,9 +253,9 @@ namespace Smdn.Devices.Mcp2221A {
     IEquatable<byte>,
     IEquatable<int>
   {
-    public static readonly I2cAddress DeviceMaxValue; // = "77"
-    public static readonly I2cAddress DeviceMinValue; // = "08"
-    public static readonly I2cAddress Zero; // = "00"
+    public static I2cAddress DeviceMaxValue { get; } // = "0x77"
+    public static I2cAddress DeviceMinValue { get; } // = "0x08"
+    public static I2cAddress Zero { get; } // = "0x00"
 
     public static I2cAddress FromByte(byte address) {}
     public static bool operator == (I2cAddress x, I2cAddress y) {}
@@ -261,18 +300,28 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource CurrentAdcReferenceSource { get; }
     int LastReadAnalogRawValue { get; }
 
-    void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource, CancellationToken cancellationToken = default);
+    void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource, CancellationToken cancellationToken = default);
     int ReadAnalogRaw(CancellationToken cancellationToken = default);
     ValueTask<int> ReadAnalogRawAsync(CancellationToken cancellationToken = default);
+  }
+
+  public interface IClockOutputController {
+    ClockOutputDutyCycle CurrentClockOutputDutyCycle { get; }
+    ClockOutputFrequency CurrentClockOutputFrequency { get; }
+
+    void ConfigureAsClockOutput(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsClockOutputAsync(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default);
+    void SuspendClockOutput(CancellationToken cancellationToken = default);
+    ValueTask SuspendClockOutputAsync(CancellationToken cancellationToken = default);
   }
 
   public interface IDacController {
     VoltageReferenceSource CurrentDacReferenceSource { get; }
     int LastWriteAnalogRawValue { get; }
 
-    void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
+    void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource, int? initialOutputValue = null, CancellationToken cancellationToken = default);
     void WriteAnalogRaw(int @value, CancellationToken cancellationToken = default);
     ValueTask WriteAnalogRawAsync(int @value, CancellationToken cancellationToken = default);
   }
@@ -298,8 +347,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public interface IGpioController {
-    void ConfigureAsGpio(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
-    ValueTask ConfigureAsGpioAsync(PinMode mode, PinValue initialValue, CancellationToken cancellationToken = default);
+    void ConfigureAsGpio(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsGpioAsync(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     PinMode GetMode(CancellationToken cancellationToken = default);
     ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default);
     PinValue Read(CancellationToken cancellationToken = default);
@@ -308,6 +357,18 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default);
     void Write(PinValue @value, CancellationToken cancellationToken = default);
     ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default);
+  }
+
+  public interface IInterruptOnChangeController {
+    InterruptOnChangeTrigger CurrentInterruptOnChangeTrigger { get; }
+    bool LastReadInterruptDetectionFlag { get; }
+
+    void ClearInterruptDetection(CancellationToken cancellationToken = default);
+    ValueTask ClearInterruptDetectionAsync(CancellationToken cancellationToken = default);
+    void ConfigureAsInterruptOnChange(InterruptOnChangeTrigger? detectionTrigger, bool clearDetectionFlag, CancellationToken cancellationToken = default);
+    ValueTask ConfigureAsInterruptOnChangeAsync(InterruptOnChangeTrigger? detectionTrigger, bool clearDetectionFlag, CancellationToken cancellationToken = default);
+    bool ReadInterruptDetection(CancellationToken cancellationToken = default);
+    ValueTask<bool> ReadInterruptDetectionAsync(CancellationToken cancellationToken = default);
   }
 
   public sealed class Gp0Controller : GpController {
@@ -324,25 +385,37 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
 
   public sealed class Gp1Controller :
     GpController,
-    IAdcController
+    IAdcController,
+    IClockOutputController,
+    IInterruptOnChangeController
   {
+    public ClockOutputDutyCycle CurrentClockOutputDutyCycle { get; }
+    public ClockOutputFrequency CurrentClockOutputFrequency { get; }
     public override string CurrentDesignation { get; }
     public override GpFunction CurrentFunction { get; }
+    public InterruptOnChangeTrigger CurrentInterruptOnChangeTrigger { get; }
     public override int Index { get; }
     public int LastReadAnalogRawValue { get; }
+    public bool LastReadInterruptDetectionFlag { get; }
     public override string PinName { get; }
     VoltageReferenceSource IAdcController.CurrentAdcReferenceSource { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsClockOutput(CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsClockOutputAsync(CancellationToken cancellationToken = default) {}
-    public void ConfigureAsExternalInterrupt(CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsExternalInterruptAsync(CancellationToken cancellationToken = default) {}
+    public void ClearInterruptDetection(CancellationToken cancellationToken = default) {}
+    public ValueTask ClearInterruptDetectionAsync(CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsClockOutput(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsClockOutputAsync(ClockOutputFrequency? frequency = null, ClockOutputDutyCycle? dutyCycle = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsInterruptOnChange(InterruptOnChangeTrigger? detectionTrigger = null, bool clearDetectionFlag = true, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsInterruptOnChangeAsync(InterruptOnChangeTrigger? detectionTrigger = null, bool clearDetectionFlag = true, CancellationToken cancellationToken = default) {}
     public void ConfigureAsUtxLedOutput(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsUtxLedOutputAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
     public async ValueTask<int> ReadAnalogRawAsync(CancellationToken cancellationToken = default) {}
+    public bool ReadInterruptDetection(CancellationToken cancellationToken = default) {}
+    public async ValueTask<bool> ReadInterruptDetectionAsync(CancellationToken cancellationToken = default) {}
+    public void SuspendClockOutput(CancellationToken cancellationToken = default) {}
+    public ValueTask SuspendClockOutputAsync(CancellationToken cancellationToken = default) {}
   }
 
   public sealed class Gp2Controller :
@@ -359,10 +432,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource IDacController.CurrentDacReferenceSource { get; }
     int IDacController.LastWriteAnalogRawValue { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
     public void ConfigureAsUsbConfigureStatus(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsUsbConfigureStatusAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
@@ -385,10 +458,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     VoltageReferenceSource IDacController.CurrentDacReferenceSource { get; }
     int IDacController.LastWriteAnalogRawValue { get; }
 
-    public void ConfigureAsAdc(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, CancellationToken cancellationToken = default) {}
-    public void ConfigureAsDac(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource voltageReferenceSource = VoltageReferenceSource.Vdd, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsAdc(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsAdcAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsDac(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsDacAsync(VoltageReferenceSource? voltageReferenceSource = (VoltageReferenceSource)0, int? initialOutputValue = null, CancellationToken cancellationToken = default) {}
     public void ConfigureAsI2cLedOutput(CancellationToken cancellationToken = default) {}
     public ValueTask ConfigureAsI2cLedOutputAsync(CancellationToken cancellationToken = default) {}
     public int ReadAnalogRaw(CancellationToken cancellationToken = default) {}
@@ -406,8 +479,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     public PinValue LastUpdatedValue { get; }
     public abstract string PinName { get; }
 
-    public void ConfigureAsGpio(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
-    public ValueTask ConfigureAsGpioAsync(PinMode mode = PinMode.Output, PinValue initialValue = default, CancellationToken cancellationToken = default) {}
+    public void ConfigureAsGpio(PinMode? mode = (PinMode)1, PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
+    public ValueTask ConfigureAsGpioAsync(PinMode? mode = (PinMode)1, PinValue? initialValue = null, CancellationToken cancellationToken = default) {}
     public PinMode GetMode(CancellationToken cancellationToken = default) {}
     public async ValueTask<PinMode> GetModeAsync(CancellationToken cancellationToken = default) {}
     public bool IsFunctionSupported(GpFunction function) {}
@@ -478,8 +551,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
   }
 
   public static class II2cControllerBusScanningExtensions {
-    public static (IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet) ScanBus(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
-    public static async ValueTask<(IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet)> ScanBusAsync(this II2cController controller, I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+    extension(II2cController controller) {
+      public (IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet) ScanBus(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public ValueTask<(IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+    }
   }
 
   public sealed class Mcp2221AI2cBus :


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #8](https://github.com/smdn/Smdn.Devices.Mcp2221A/actions/runs/25000716947).

# Release target
- package_target_tag: `new-release/main/Smdn.Devices.Mcp2221A-1.0.0-preview4`
- package_prevver_ref: `releases/Smdn.Devices.Mcp2221A-1.0.0-preview3`
- package_prevver_tag: `releases/Smdn.Devices.Mcp2221A-1.0.0-preview3`
- package_id: `Smdn.Devices.Mcp2221A`
- package_id_with_version: `Smdn.Devices.Mcp2221A-1.0.0-preview4`
- package_version: `1.0.0-preview4`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Devices.Mcp2221A-1.0.0-preview4-1777299861`
- release_tag: `releases/Smdn.Devices.Mcp2221A-1.0.0-preview4`
- release_prerelease: `True` ❗Change this value to 	rue to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/5450ee03df9b43dd6670de05fbd39db0`](https://gist.github.com/smdn/5450ee03df9b43dd6670de05fbd39db0)
- artifact_name_nupkg: `Smdn.Devices.Mcp2221A.1.0.0-preview4.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.
- artifact_digest_nupkg: `sha256:ffd735fe4c3d421c77a882e1d14550a1bc460351943d0222c7757d7aaed803ae`

# .nuspec diff
```diff
--- Smdn.Devices.Mcp2221A.latest.nuspec
+++ Smdn.Devices.Mcp2221A.1.0.0-preview4.nuspec
@@ -1,45 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Devices.Mcp2221A</id>
-    <version>1.0.0-preview3</version>
+    <version>1.0.0-preview4</version>
     <title>Smdn.Devices.Mcp2221A</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Devices.Mcp2221A.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://smdn.jp/electronics/libs/Smdn.Devices.MCP2221/</projectUrl>
     <description>`Smdn.Devices.Mcp2221A` is a .NET library for the **Microchip Technology MCP2221 and MCP2221A, a USB2.0 to I2C/UART Protocol Converter with GPIO**. This library provides APIs that enable .NET applications to access the functions of the MCP2221/MCP2221A via the USB HID interface.</description>
-    <releaseNotes>See the release notes for [Smdn.Devices.Mcp2221A version 1.0.0-preview3](https://github.com/smdn/Smdn.Devices.Mcp2221A/releases/tag/releases%2FSmdn.Devices.Mcp2221A-1.0.0-preview3) on GitHub Releases.</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>See the release notes for [Smdn.Devices.Mcp2221A version 1.0.0-preview4](https://github.com/smdn/Smdn.Devices.Mcp2221A/releases/tag/releases%2FSmdn.Devices.Mcp2221A-1.0.0-preview4) on GitHub Releases.</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp USB,USB-HID,MCP2221,MCP2221A,I2C,GPIO,System.Device.Gpio</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Devices.Mcp2221A" branch="main" commit="d42e385fe4b06f0ecfa89ea8ad4b2b176d8a4667" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Devices.Mcp2221A" commit="a24148124a7d6bbdc25f3748eb0d77bcf6a78f49" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Device.Gpio" version="[4.1.0, 5.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net10.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Device.Gpio" version="[4.1.0, 5.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Device.Gpio" version="[1.5.0, 4.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Device.Gpio" version="[1.5.0, 4.0.0)" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net10.0/Smdn.Devices.Mcp2221A.dll" target="lib/net10.0/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net10.0/Smdn.Devices.Mcp2221A.xml" target="lib/net10.0/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net8.0/Smdn.Devices.Mcp2221A.dll" target="lib/net8.0/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net8.0/Smdn.Devices.Mcp2221A.xml" target="lib/net8.0/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.0/Smdn.Devices.Mcp2221A.dll" target="lib/netstandard2.0/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.0/Smdn.Devices.Mcp2221A.xml" target="lib/netstandard2.0/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.1/Smdn.Devices.Mcp2221A.dll" target="lib/netstandard2.1/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.1/Smdn.Devices.Mcp2221A.xml" target="lib/netstandard2.1/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/.nuget/packages/smdn.msbuild.projectassets.common/1.7.1/project/images/package-icon.png" target="Smdn.Devices.Mcp2221A.png" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

