### PR TITLE
Release main/Smdn.Devices.Mcp2221A-1.0.0

### DIFF
--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-net10.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-net10.0.apilist.cs
@@ -1,16 +1,16 @@
-// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview4)
+// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0)
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview4+a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
+//   InformationalVersion: 1.0.0+0bf9c954cff7b4ca33c418cbc5e863d9862124f3
 //   TargetFramework: .NETCoreApp,Version=v10.0
 //   Configuration: Release
 //   Metadata: IsTrimmable=True
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
-//   Metadata: RepositoryCommit=a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
+//   Metadata: RepositoryCommit=0bf9c954cff7b4ca33c418cbc5e863d9862124f3
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
-//     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.IO.UsbHid.Abstractions, Version=1.0.0.0, Culture=neutral
 //     System.Collections, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.Device.Gpio;
 using System.Device.I2c;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.Devices.Mcp2221A;
@@ -61,6 +62,13 @@ namespace Smdn.Devices.Mcp2221A {
     Reserved = 0,
   }
 
+  public enum DeviceConfigurationProtectionLevel : int {
+    None = 0,
+    PasswordProtected = 1,
+    PermanentlyLocked = 2,
+    Reserved = 3,
+  }
+
   public enum GpFunction : int {
     Adc = 1,
     ClockOutput = 5,
@@ -77,6 +85,11 @@ namespace Smdn.Devices.Mcp2221A {
     Falling = 2,
     None = 0,
     Rising = 1,
+  }
+
+  public enum UsbPowerMode : int {
+    BusPowered = 0,
+    SelfPowered = 1,
   }
 
   public enum VoltageReferenceSource : int {
@@ -215,6 +228,7 @@ namespace Smdn.Devices.Mcp2221A {
     public VoltageReferenceSource CurrentAdcReferenceSource { get; }
     public VoltageReferenceSource CurrentDacReferenceSource { get; }
     public string FirmwareRevision { get; }
+    public DeviceConfigurationProtectionLevel FlashWriteProtection { get; }
     public Gp0Controller GpPin0 { get; }
     public Gp1Controller GpPin1 { get; }
     public Gp2Controller GpPin2 { get; }
@@ -228,6 +242,12 @@ namespace Smdn.Devices.Mcp2221A {
     public string Manufacturer { get; }
     public string Product { get; }
     public string SerialNumber { get; }
+    public bool UsbCdcSerialNumberEnabled { get; }
+    public UsbPowerMode UsbPowerMode { get; }
+    public int UsbProductId { get; }
+    public bool UsbRemoteWakeUpEnabled { get; }
+    public int UsbRequestedCurrentAmount { get; }
+    public int UsbVendorId { get; }
 
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
@@ -256,6 +276,7 @@ namespace Smdn.Devices.Mcp2221A {
 
   public readonly struct I2cAddress :
     IComparable<I2cAddress>,
+    IComparisonOperators<I2cAddress, I2cAddress, bool>,
     IEquatable<I2cAddress>,
     IEquatable<byte>,
     IEquatable<int>
@@ -354,6 +375,9 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public interface IGpioController {
+    PinMode CurrentMode { get; }
+    PinValue LastUpdatedValue { get; }
+
     void ConfigureAsGpio(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     ValueTask ConfigureAsGpioAsync(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     PinMode GetMode(CancellationToken cancellationToken = default);
@@ -478,6 +502,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public abstract class GpController : IGpioController {
+    public PinMode ConfiguredMode { get; }
+    public PinValue ConfiguredOutputValue { get; }
     public abstract string CurrentDesignation { get; }
     public abstract GpFunction CurrentFunction { get; }
     public PinMode CurrentMode { get; }
@@ -495,7 +521,6 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     public async ValueTask<PinValue> ReadAsync(CancellationToken cancellationToken = default) {}
     public void SetMode(PinMode mode, CancellationToken cancellationToken = default) {}
     public async ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default) {}
-    protected void ThrowIfInvalidConfiguration(GpFunction requiredFunction) {}
     public void Write(PinValue @value, CancellationToken cancellationToken = default) {}
     public async ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default) {}
   }
@@ -543,24 +568,22 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
 
   public class I2cNackException : I2cCommandException {
     public I2cNackException() {}
-    public I2cNackException(I2cAddress address) {}
-    public I2cNackException(I2cAddress address, Exception? innerException) {}
+    public I2cNackException(I2cAddress address, string? message = null, Exception? innerException = null) {}
     public I2cNackException(string? message) {}
     public I2cNackException(string? message, Exception? innerException) {}
   }
 
   public class I2cReadException : I2cCommandException {
     public I2cReadException() {}
-    public I2cReadException(I2cAddress address, string? message) {}
-    public I2cReadException(I2cAddress address, string? message, Exception? innerException) {}
+    public I2cReadException(I2cAddress address, string? message = null, Exception? innerException = null) {}
     public I2cReadException(string? message) {}
     public I2cReadException(string? message, Exception? innerException) {}
   }
 
   public static class II2cControllerBusScanningExtensions {
     extension(II2cController controller) {
-      public (IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet) ScanBus(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
-      public ValueTask<(IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public (IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet) ScanBus(I2cAddress fromAddress = default, I2cAddress toAddress = default, int transmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public ValueTask<(IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress fromAddress = default, I2cAddress toAddress = default, int transmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
     }
   }
 
@@ -604,10 +627,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
   }
 
   public readonly struct I2cScanBusProgress {
-    public I2cAddress AddressRangeMax { get; }
-    public I2cAddress AddressRangeMin { get; }
+    public I2cAddress CurrentAddress { get; }
+    public I2cAddress FromAddress { get; }
     public int ProgressInPercent { get; }
-    public I2cAddress ScanningAddress { get; }
+    public I2cAddress ToAddress { get; }
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.8.2.0.

--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-net8.0.apilist.cs
@@ -1,16 +1,16 @@
-// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview4)
+// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0)
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview4+a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
+//   InformationalVersion: 1.0.0+0bf9c954cff7b4ca33c418cbc5e863d9862124f3
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Metadata: IsTrimmable=True
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
-//   Metadata: RepositoryCommit=a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
+//   Metadata: RepositoryCommit=0bf9c954cff7b4ca33c418cbc5e863d9862124f3
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
-//     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.IO.UsbHid.Abstractions, Version=1.0.0.0, Culture=neutral
 //     System.Collections, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.Device.Gpio;
 using System.Device.I2c;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.Devices.Mcp2221A;
@@ -61,6 +62,13 @@ namespace Smdn.Devices.Mcp2221A {
     Reserved = 0,
   }
 
+  public enum DeviceConfigurationProtectionLevel : int {
+    None = 0,
+    PasswordProtected = 1,
+    PermanentlyLocked = 2,
+    Reserved = 3,
+  }
+
   public enum GpFunction : int {
     Adc = 1,
     ClockOutput = 5,
@@ -77,6 +85,11 @@ namespace Smdn.Devices.Mcp2221A {
     Falling = 2,
     None = 0,
     Rising = 1,
+  }
+
+  public enum UsbPowerMode : int {
+    BusPowered = 0,
+    SelfPowered = 1,
   }
 
   public enum VoltageReferenceSource : int {
@@ -215,6 +228,7 @@ namespace Smdn.Devices.Mcp2221A {
     public VoltageReferenceSource CurrentAdcReferenceSource { get; }
     public VoltageReferenceSource CurrentDacReferenceSource { get; }
     public string FirmwareRevision { get; }
+    public DeviceConfigurationProtectionLevel FlashWriteProtection { get; }
     public Gp0Controller GpPin0 { get; }
     public Gp1Controller GpPin1 { get; }
     public Gp2Controller GpPin2 { get; }
@@ -228,6 +242,12 @@ namespace Smdn.Devices.Mcp2221A {
     public string Manufacturer { get; }
     public string Product { get; }
     public string SerialNumber { get; }
+    public bool UsbCdcSerialNumberEnabled { get; }
+    public UsbPowerMode UsbPowerMode { get; }
+    public int UsbProductId { get; }
+    public bool UsbRemoteWakeUpEnabled { get; }
+    public int UsbRequestedCurrentAmount { get; }
+    public int UsbVendorId { get; }
 
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
@@ -256,6 +276,7 @@ namespace Smdn.Devices.Mcp2221A {
 
   public readonly struct I2cAddress :
     IComparable<I2cAddress>,
+    IComparisonOperators<I2cAddress, I2cAddress, bool>,
     IEquatable<I2cAddress>,
     IEquatable<byte>,
     IEquatable<int>
@@ -354,6 +375,9 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public interface IGpioController {
+    PinMode CurrentMode { get; }
+    PinValue LastUpdatedValue { get; }
+
     void ConfigureAsGpio(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     ValueTask ConfigureAsGpioAsync(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     PinMode GetMode(CancellationToken cancellationToken = default);
@@ -478,6 +502,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public abstract class GpController : IGpioController {
+    public PinMode ConfiguredMode { get; }
+    public PinValue ConfiguredOutputValue { get; }
     public abstract string CurrentDesignation { get; }
     public abstract GpFunction CurrentFunction { get; }
     public PinMode CurrentMode { get; }
@@ -495,7 +521,6 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     public async ValueTask<PinValue> ReadAsync(CancellationToken cancellationToken = default) {}
     public void SetMode(PinMode mode, CancellationToken cancellationToken = default) {}
     public async ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default) {}
-    protected void ThrowIfInvalidConfiguration(GpFunction requiredFunction) {}
     public void Write(PinValue @value, CancellationToken cancellationToken = default) {}
     public async ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default) {}
   }
@@ -543,24 +568,22 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
 
   public class I2cNackException : I2cCommandException {
     public I2cNackException() {}
-    public I2cNackException(I2cAddress address) {}
-    public I2cNackException(I2cAddress address, Exception? innerException) {}
+    public I2cNackException(I2cAddress address, string? message = null, Exception? innerException = null) {}
     public I2cNackException(string? message) {}
     public I2cNackException(string? message, Exception? innerException) {}
   }
 
   public class I2cReadException : I2cCommandException {
     public I2cReadException() {}
-    public I2cReadException(I2cAddress address, string? message) {}
-    public I2cReadException(I2cAddress address, string? message, Exception? innerException) {}
+    public I2cReadException(I2cAddress address, string? message = null, Exception? innerException = null) {}
     public I2cReadException(string? message) {}
     public I2cReadException(string? message, Exception? innerException) {}
   }
 
   public static class II2cControllerBusScanningExtensions {
     extension(II2cController controller) {
-      public (IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet) ScanBus(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
-      public ValueTask<(IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public (IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet) ScanBus(I2cAddress fromAddress = default, I2cAddress toAddress = default, int transmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public ValueTask<(IReadOnlySet<I2cAddress> WriteAddressSet, IReadOnlySet<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress fromAddress = default, I2cAddress toAddress = default, int transmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
     }
   }
 
@@ -604,10 +627,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
   }
 
   public readonly struct I2cScanBusProgress {
-    public I2cAddress AddressRangeMax { get; }
-    public I2cAddress AddressRangeMin { get; }
+    public I2cAddress CurrentAddress { get; }
+    public I2cAddress FromAddress { get; }
     public int ProgressInPercent { get; }
-    public I2cAddress ScanningAddress { get; }
+    public I2cAddress ToAddress { get; }
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.8.2.0.

--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.0.apilist.cs
@@ -1,16 +1,16 @@
-// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview4)
+// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0)
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview4+a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
+//   InformationalVersion: 1.0.0+0bf9c954cff7b4ca33c418cbc5e863d9862124f3
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
-//   Metadata: RepositoryCommit=a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
+//   Metadata: RepositoryCommit=0bf9c954cff7b4ca33c418cbc5e863d9862124f3
 //   Referenced assemblies:
 //     Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
-//     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.IO.UsbHid.Abstractions, Version=1.0.0.0, Culture=neutral
 //     System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Device.Gpio, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
@@ -58,6 +58,13 @@ namespace Smdn.Devices.Mcp2221A {
     Reserved = 0,
   }
 
+  public enum DeviceConfigurationProtectionLevel : int {
+    None = 0,
+    PasswordProtected = 1,
+    PermanentlyLocked = 2,
+    Reserved = 3,
+  }
+
   public enum GpFunction : int {
     Adc = 1,
     ClockOutput = 5,
@@ -74,6 +81,11 @@ namespace Smdn.Devices.Mcp2221A {
     Falling = 2,
     None = 0,
     Rising = 1,
+  }
+
+  public enum UsbPowerMode : int {
+    BusPowered = 0,
+    SelfPowered = 1,
   }
 
   public enum VoltageReferenceSource : int {
@@ -212,6 +224,7 @@ namespace Smdn.Devices.Mcp2221A {
     public VoltageReferenceSource CurrentAdcReferenceSource { get; }
     public VoltageReferenceSource CurrentDacReferenceSource { get; }
     public string FirmwareRevision { get; }
+    public DeviceConfigurationProtectionLevel FlashWriteProtection { get; }
     public Gp0Controller GpPin0 { get; }
     public Gp1Controller GpPin1 { get; }
     public Gp2Controller GpPin2 { get; }
@@ -225,6 +238,12 @@ namespace Smdn.Devices.Mcp2221A {
     public string Manufacturer { get; }
     public string Product { get; }
     public string SerialNumber { get; }
+    public bool UsbCdcSerialNumberEnabled { get; }
+    public UsbPowerMode UsbPowerMode { get; }
+    public int UsbProductId { get; }
+    public bool UsbRemoteWakeUpEnabled { get; }
+    public int UsbRequestedCurrentAmount { get; }
+    public int UsbVendorId { get; }
 
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
@@ -351,6 +370,9 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public interface IGpioController {
+    PinMode CurrentMode { get; }
+    PinValue LastUpdatedValue { get; }
+
     void ConfigureAsGpio(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     ValueTask ConfigureAsGpioAsync(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     PinMode GetMode(CancellationToken cancellationToken = default);
@@ -475,6 +497,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public abstract class GpController : IGpioController {
+    public PinMode ConfiguredMode { get; }
+    public PinValue ConfiguredOutputValue { get; }
     public abstract string CurrentDesignation { get; }
     public abstract GpFunction CurrentFunction { get; }
     public PinMode CurrentMode { get; }
@@ -492,7 +516,6 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     public async ValueTask<PinValue> ReadAsync(CancellationToken cancellationToken = default) {}
     public void SetMode(PinMode mode, CancellationToken cancellationToken = default) {}
     public async ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default) {}
-    protected void ThrowIfInvalidConfiguration(GpFunction requiredFunction) {}
     public void Write(PinValue @value, CancellationToken cancellationToken = default) {}
     public async ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default) {}
   }
@@ -540,24 +563,22 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
 
   public class I2cNackException : I2cCommandException {
     public I2cNackException() {}
-    public I2cNackException(I2cAddress address) {}
-    public I2cNackException(I2cAddress address, Exception? innerException) {}
+    public I2cNackException(I2cAddress address, string? message = null, Exception? innerException = null) {}
     public I2cNackException(string? message) {}
     public I2cNackException(string? message, Exception? innerException) {}
   }
 
   public class I2cReadException : I2cCommandException {
     public I2cReadException() {}
-    public I2cReadException(I2cAddress address, string? message) {}
-    public I2cReadException(I2cAddress address, string? message, Exception? innerException) {}
+    public I2cReadException(I2cAddress address, string? message = null, Exception? innerException = null) {}
     public I2cReadException(string? message) {}
     public I2cReadException(string? message, Exception? innerException) {}
   }
 
   public static class II2cControllerBusScanningExtensions {
     extension(II2cController controller) {
-      public (IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet) ScanBus(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
-      public ValueTask<(IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public (IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet) ScanBus(I2cAddress fromAddress = default, I2cAddress toAddress = default, int transmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public ValueTask<(IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress fromAddress = default, I2cAddress toAddress = default, int transmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
     }
   }
 
@@ -600,10 +621,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
   }
 
   public readonly struct I2cScanBusProgress {
-    public I2cAddress AddressRangeMax { get; }
-    public I2cAddress AddressRangeMin { get; }
+    public I2cAddress CurrentAddress { get; }
+    public I2cAddress FromAddress { get; }
     public int ProgressInPercent { get; }
-    public I2cAddress ScanningAddress { get; }
+    public I2cAddress ToAddress { get; }
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.8.2.0.

--- a/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A-netstandard2.1.apilist.cs
@@ -1,15 +1,15 @@
-// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0-preview4)
+// Smdn.Devices.Mcp2221A.dll (Smdn.Devices.Mcp2221A-1.0.0)
 //   Name: Smdn.Devices.Mcp2221A
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-preview4+a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
+//   InformationalVersion: 1.0.0+0bf9c954cff7b4ca33c418cbc5e863d9862124f3
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Metadata: RepositoryUrl=https://github.com/smdn/Smdn.Devices.Mcp2221A
 //   Metadata: RepositoryBranch=main
-//   Metadata: RepositoryCommit=a24148124a7d6bbdc25f3748eb0d77bcf6a78f49
+//   Metadata: RepositoryCommit=0bf9c954cff7b4ca33c418cbc5e863d9862124f3
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
-//     Microsoft.Extensions.Logging.Abstractions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.IO.UsbHid.Abstractions, Version=1.0.0.0, Culture=neutral
 //     System.Device.Gpio, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
@@ -54,6 +54,13 @@ namespace Smdn.Devices.Mcp2221A {
     Reserved = 0,
   }
 
+  public enum DeviceConfigurationProtectionLevel : int {
+    None = 0,
+    PasswordProtected = 1,
+    PermanentlyLocked = 2,
+    Reserved = 3,
+  }
+
   public enum GpFunction : int {
     Adc = 1,
     ClockOutput = 5,
@@ -70,6 +77,11 @@ namespace Smdn.Devices.Mcp2221A {
     Falling = 2,
     None = 0,
     Rising = 1,
+  }
+
+  public enum UsbPowerMode : int {
+    BusPowered = 0,
+    SelfPowered = 1,
   }
 
   public enum VoltageReferenceSource : int {
@@ -208,6 +220,7 @@ namespace Smdn.Devices.Mcp2221A {
     public VoltageReferenceSource CurrentAdcReferenceSource { get; }
     public VoltageReferenceSource CurrentDacReferenceSource { get; }
     public string FirmwareRevision { get; }
+    public DeviceConfigurationProtectionLevel FlashWriteProtection { get; }
     public Gp0Controller GpPin0 { get; }
     public Gp1Controller GpPin1 { get; }
     public Gp2Controller GpPin2 { get; }
@@ -221,6 +234,12 @@ namespace Smdn.Devices.Mcp2221A {
     public string Manufacturer { get; }
     public string Product { get; }
     public string SerialNumber { get; }
+    public bool UsbCdcSerialNumberEnabled { get; }
+    public UsbPowerMode UsbPowerMode { get; }
+    public int UsbProductId { get; }
+    public bool UsbRemoteWakeUpEnabled { get; }
+    public int UsbRequestedCurrentAmount { get; }
+    public int UsbVendorId { get; }
 
     public void Dispose() {}
     public async ValueTask DisposeAsync() {}
@@ -347,6 +366,9 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public interface IGpioController {
+    PinMode CurrentMode { get; }
+    PinValue LastUpdatedValue { get; }
+
     void ConfigureAsGpio(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     ValueTask ConfigureAsGpioAsync(PinMode? mode, PinValue? initialValue, CancellationToken cancellationToken = default);
     PinMode GetMode(CancellationToken cancellationToken = default);
@@ -471,6 +493,8 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
   }
 
   public abstract class GpController : IGpioController {
+    public PinMode ConfiguredMode { get; }
+    public PinValue ConfiguredOutputValue { get; }
     public abstract string CurrentDesignation { get; }
     public abstract GpFunction CurrentFunction { get; }
     public PinMode CurrentMode { get; }
@@ -488,7 +512,6 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.Gpio {
     public async ValueTask<PinValue> ReadAsync(CancellationToken cancellationToken = default) {}
     public void SetMode(PinMode mode, CancellationToken cancellationToken = default) {}
     public async ValueTask SetModeAsync(PinMode mode, CancellationToken cancellationToken = default) {}
-    protected void ThrowIfInvalidConfiguration(GpFunction requiredFunction) {}
     public void Write(PinValue @value, CancellationToken cancellationToken = default) {}
     public async ValueTask WriteAsync(PinValue @value, CancellationToken cancellationToken = default) {}
   }
@@ -536,24 +559,22 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
 
   public class I2cNackException : I2cCommandException {
     public I2cNackException() {}
-    public I2cNackException(I2cAddress address) {}
-    public I2cNackException(I2cAddress address, Exception? innerException) {}
+    public I2cNackException(I2cAddress address, string? message = null, Exception? innerException = null) {}
     public I2cNackException(string? message) {}
     public I2cNackException(string? message, Exception? innerException) {}
   }
 
   public class I2cReadException : I2cCommandException {
     public I2cReadException() {}
-    public I2cReadException(I2cAddress address, string? message) {}
-    public I2cReadException(I2cAddress address, string? message, Exception? innerException) {}
+    public I2cReadException(I2cAddress address, string? message = null, Exception? innerException = null) {}
     public I2cReadException(string? message) {}
     public I2cReadException(string? message, Exception? innerException) {}
   }
 
   public static class II2cControllerBusScanningExtensions {
     extension(II2cController controller) {
-      public (IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet) ScanBus(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
-      public ValueTask<(IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress addressRangeMin = default, I2cAddress addressRangeMax = default, int i2cBusTransmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public (IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet) ScanBus(I2cAddress fromAddress = default, I2cAddress toAddress = default, int transmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
+      public ValueTask<(IReadOnlyCollection<I2cAddress> WriteAddressSet, IReadOnlyCollection<I2cAddress> ReadAddressSet)> ScanBusAsync(I2cAddress fromAddress = default, I2cAddress toAddress = default, int transmissionSpeedInKbps = 100, IProgress<I2cScanBusProgress>? progress = null, CancellationToken cancellationToken = default) {}
     }
   }
 
@@ -596,10 +617,10 @@ namespace Smdn.Devices.Mcp2221A.Peripherals.I2c {
   }
 
   public readonly struct I2cScanBusProgress {
-    public I2cAddress AddressRangeMax { get; }
-    public I2cAddress AddressRangeMin { get; }
+    public I2cAddress CurrentAddress { get; }
+    public I2cAddress FromAddress { get; }
     public int ProgressInPercent { get; }
-    public I2cAddress ScanningAddress { get; }
+    public I2cAddress ToAddress { get; }
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.8.2.0.


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #9](https://github.com/smdn/Smdn.Devices.Mcp2221A/actions/runs/25416712916).

# Release target
- package_target_tag: `new-release/main/Smdn.Devices.Mcp2221A-1.0.0`
- package_prevver_ref: `releases/Smdn.Devices.Mcp2221A-1.0.0-preview4`
- package_prevver_tag: `releases/Smdn.Devices.Mcp2221A-1.0.0-preview4`
- package_id: `Smdn.Devices.Mcp2221A`
- package_id_with_version: `Smdn.Devices.Mcp2221A-1.0.0`
- package_version: `1.0.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Devices.Mcp2221A-1.0.0-1778042231`
- release_tag: `releases/Smdn.Devices.Mcp2221A-1.0.0`
- release_prerelease: `False` ❗Change this value to 	rue to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/924603c30b2f9cceed4b3ff9ed1152b1`](https://gist.github.com/smdn/924603c30b2f9cceed4b3ff9ed1152b1)
- artifact_name_nupkg: `Smdn.Devices.Mcp2221A.1.0.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.
- artifact_digest_nupkg: `sha256:6306af0c9ad57ad73022597c428e6d13afce23214e4d031c08e61f2654e94bf2`

# .nuspec diff
```diff
--- Smdn.Devices.Mcp2221A.latest.nuspec
+++ Smdn.Devices.Mcp2221A.1.0.0.nuspec
@@ -1,45 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Devices.Mcp2221A</id>
-    <version>1.0.0-preview4</version>
+    <version>1.0.0</version>
     <title>Smdn.Devices.Mcp2221A</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Devices.Mcp2221A.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://smdn.jp/electronics/libs/Smdn.Devices.MCP2221/</projectUrl>
     <description>`Smdn.Devices.Mcp2221A` is a .NET library for the **Microchip Technology MCP2221 and MCP2221A, a USB2.0 to I2C/UART Protocol Converter with GPIO**. This library provides APIs that enable .NET applications to access the functions of the MCP2221/MCP2221A via the USB HID interface.</description>
-    <releaseNotes>See the release notes for [Smdn.Devices.Mcp2221A version 1.0.0-preview4](https://github.com/smdn/Smdn.Devices.Mcp2221A/releases/tag/releases%2FSmdn.Devices.Mcp2221A-1.0.0-preview4) on GitHub Releases.</releaseNotes>
-    <copyright>Copyright � 2021 smdn</copyright>
+    <releaseNotes>See the release notes for [Smdn.Devices.Mcp2221A version 1.0.0](https://github.com/smdn/Smdn.Devices.Mcp2221A/releases/tag/releases%2FSmdn.Devices.Mcp2221A-1.0.0) on GitHub Releases.</releaseNotes>
+    <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp USB,USB-HID,MCP2221,MCP2221A,I2C,GPIO,System.Device.Gpio</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Devices.Mcp2221A" branch="main" commit="a24148124a7d6bbdc25f3748eb0d77bcf6a78f49" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Devices.Mcp2221A" commit="0bf9c954cff7b4ca33c418cbc5e863d9862124f3" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Logging" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Device.Gpio" version="[4.1.0, 5.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net10.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Logging" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Device.Gpio" version="[4.1.0, 5.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Logging" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Device.Gpio" version="[1.5.0, 4.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Extensions.Logging" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Logging" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.IO.UsbHid.Abstractions" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Device.Gpio" version="[1.5.0, 4.0.0)" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net10.0/Smdn.Devices.Mcp2221A.dll" target="lib/net10.0/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net10.0/Smdn.Devices.Mcp2221A.xml" target="lib/net10.0/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net8.0/Smdn.Devices.Mcp2221A.dll" target="lib/net8.0/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/net8.0/Smdn.Devices.Mcp2221A.xml" target="lib/net8.0/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.0/Smdn.Devices.Mcp2221A.dll" target="lib/netstandard2.0/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.0/Smdn.Devices.Mcp2221A.xml" target="lib/netstandard2.0/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.1/Smdn.Devices.Mcp2221A.dll" target="lib/netstandard2.1/Smdn.Devices.Mcp2221A.dll" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/netstandard2.1/Smdn.Devices.Mcp2221A.xml" target="lib/netstandard2.1/Smdn.Devices.Mcp2221A.xml" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/.nuget/packages/smdn.msbuild.projectassets.common/1.7.1/project/images/package-icon.png" target="Smdn.Devices.Mcp2221A.png" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.Devices.Mcp2221A/Smdn.Devices.Mcp2221A/src/Smdn.Devices.Mcp2221A/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

